### PR TITLE
implementation of remote resources in IIIF manifests for virtual objects

### DIFF
--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -98,8 +98,10 @@ class IiifPresentationManifest
     manifest
   end
 
+  ##
+  # @param [Integer] count This is the i_th (image) resource
   def canvas_for_resource(purl_base_uri, resource, count)
-    url = stacks_iiif_base_url(druid, resource.filename)
+    url = stacks_iiif_base_url(resource.druid, resource.filename)
 
     canv = IIIF::Presentation::Canvas.new
     canv['@id'] = "#{purl_base_uri}/iiif/canvas-#{count}"
@@ -167,14 +169,14 @@ class IiifPresentationManifest
     thumb
   end
 
+  # If not available, use the first image to create a thumbnail on the manifest
   def thumbnail_image
     @thumbnail_image ||= page_images.detect(&:thumbnail?) || page_images.first
   end
 
   def thumbnail_base_uri
     @thumbnail_base_uri ||= begin
-      # Use the first image to create a thumbnail on the manifest
-      stacks_iiif_base_url(druid, thumbnail_image.filename) if thumbnail_image
+      stacks_iiif_base_url(thumbnail_image.druid, thumbnail_image.filename) if thumbnail_image
     end
   end
 

--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -64,6 +64,7 @@ class PurlResource
     public_xml?
   end
 
+  # Fetches the body of the public XML from the public_xml resource
   def public_xml_document
     @public_xml_document ||= Nokogiri::XML(public_xml_body)
   end

--- a/spec/fixtures/document_cache/cg/767/mn/6478/contentMetadata
+++ b/spec/fixtures/document_cache/cg/767/mn/6478/contentMetadata
@@ -1,0 +1,15 @@
+<contentMetadata objectId="cg767mn6478" type="image">
+  <resource id="cg767mn6478_1" sequence="1" type="image">
+    <label>Image 1</label>
+    <file id="2542A.tif" preserve="yes" publish="no" shelve="no" mimetype="image/tiff" size="92217124">
+      <checksum type="md5">5b79c8570b7ef582735f912aa24ce5f2</checksum>
+      <checksum type="sha1">1f09f8796bfa67db97557f3de48a96c87b286d32</checksum>
+      <imageData width="6475" height="4747"/>
+    </file>
+    <file id="2542A.jp2" mimetype="image/jp2" size="5789764" preserve="no" publish="yes" shelve="yes">
+      <checksum type="md5">cd5ca5c4666cfd5ce0e9dc8c83461d7a</checksum>
+      <checksum type="sha1">39feed6ee1b734cab2d6a446e909a9fc7ac6fd01</checksum>
+      <imageData width="6475" height="4747"/>
+    </file>
+  </resource>
+</contentMetadata>

--- a/spec/fixtures/document_cache/cg/767/mn/6478/dc
+++ b/spec/fixtures/document_cache/cg/767/mn/6478/dc
@@ -1,0 +1,18 @@
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+        
+        <dc:title>(Covers to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</dc:title>
+    <dc:title>Cover: Carey's American atlas.</dc:title>
+    <dc:contributor>Carey, Mathew (author)</dc:contributor>    
+                            <dc:type>Covers</dc:type>
+        <dc:type>Book covers</dc:type>
+        
+    <dc:date>1795</dc:date><dc:publisher>Mathew Carey</dc:publisher>
+    <dc:language>eng</dc:language>
+    <dc:format>37 x 24 cm</dc:format><dc:format>image/jpeg</dc:format>
+                    <dc:coverage>United States</dc:coverage>
+                    <dc:coverage>E1200000 W0300000 N0760000 S0590000</dc:coverage>
+        
+    <dc:identifier>2542A</dc:identifier>
+    <dc:identifier>2542A</dc:identifier>
+    
+<dc:relation type="collection">David Rumsey Map Collection at Stanford University Libraries</dc:relation></oai_dc:dc>

--- a/spec/fixtures/document_cache/cg/767/mn/6478/identityMetadata
+++ b/spec/fixtures/document_cache/cg/767/mn/6478/identityMetadata
@@ -1,0 +1,11 @@
+<identityMetadata>
+  <sourceId source="Rumsey">2542A</sourceId>
+  <objectId>druid:cg767mn6478</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Cover: Carey's American atlas.</objectLabel>
+  <objectType>item</objectType>
+  <otherId name="label"/>
+  <otherId name="uuid">804cfb1a-1f4e-11e5-b0dc-0050569b3c3c</otherId>
+  <tag>Project : Rumsey : AtlasProto</tag>
+  <tag>Remediated By : 4.21.4</tag>
+</identityMetadata>

--- a/spec/fixtures/document_cache/cg/767/mn/6478/mods
+++ b/spec/fixtures/document_cache/cg/767/mn/6478/mods
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd" version="3.5">
+  <typeOfResource>cartographic</typeOfResource>
+  <titleInfo>
+    <title>(Covers to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</title>
+  </titleInfo>
+  <titleInfo type="alternative" displayLabel="Short title">
+    <title>Cover: Carey's American atlas.</title>
+  </titleInfo>
+  <name type="personal" usage="primary">
+    <namePart>Carey, Mathew</namePart>
+    <role>
+      <roleTerm type="text" authority="marcrelator">author</roleTerm>
+    </role>
+  </name>
+  <genre>Covers</genre>
+  <genre authority="gmgpc" valueURI="http://id.loc.gov/vocabulary/graphicMaterials/tgm001202">Book covers</genre>
+  <originInfo eventType="publication">
+    <place>
+      <placeTerm type="text">Philadelphia</placeTerm>
+    </place>
+    <publisher>Mathew Carey</publisher>
+    <dateIssued encoding="w3cdtf" keyDate="yes">1795</dateIssued>
+  </originInfo>
+  <language>
+    <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+  </language>
+  <physicalDescription>
+    <extent>37 x 24 cm</extent>
+    <digitalOrigin>reformatted digital</digitalOrigin>
+    <internetMediaType>image/jpeg</internetMediaType>
+  </physicalDescription>
+  <subject displayLabel="Country">
+    <geographic>United States</geographic>
+  </subject>
+  <subject>
+    <cartographics>
+      <coordinates>E1200000 W0300000 N0760000 S0590000</coordinates>
+    </cartographics>
+  </subject>
+  <relatedItem type="host" displayLabel="Appears in">
+    <titleInfo>
+      <title>Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</title>
+    </titleInfo>
+    <originInfo eventType="publication">
+      <dateIssued>1795</dateIssued>
+    </originInfo>
+    <identifier type="local" displayLabel="Pub list no.">2542</identifier>
+  </relatedItem>
+  <identifier type="local" displayLabel="List number">2542A</identifier>
+  <identifier type="local" displayLabel="Image number">2542A</identifier>
+  <recordInfo>
+    <languageOfCataloging>
+      <languageTerm authority="iso639-2b">eng</languageTerm>
+    </languageOfCataloging>
+    <recordContentSource authority="marcorg">CSt</recordContentSource>
+  </recordInfo>
+  <relatedItem type="host">
+    <titleInfo>
+      <title>David Rumsey Map Collection at Stanford University Libraries</title>
+    </titleInfo>
+    <identifier type="uri">http://purl.stanford.edu/xh235dd9059</identifier>
+    <typeOfResource collection="yes"/>
+  </relatedItem>
+  <accessCondition type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu.</accessCondition>
+  <accessCondition type="copyright">Property rights reside with the repository, Copyright © Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.</accessCondition>
+  <accessCondition type="license">CC by-nc-sa: Attribution Non-Commercial Share Alike 3.0 Unported</accessCondition>
+</mods>

--- a/spec/fixtures/document_cache/cg/767/mn/6478/public
+++ b/spec/fixtures/document_cache/cg/767/mn/6478/public
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:cg767mn6478" published="2015-10-23T19:41:06-07:00" publishVersion="dor-services/4.22.3">
+  <identityMetadata>
+    <sourceId source="Rumsey">2542A</sourceId>
+    <objectId>druid:cg767mn6478</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>Cover: Carey's American atlas.</objectLabel>
+    <objectType>item</objectType>
+    <otherId name="label"/>
+    <otherId name="uuid">804cfb1a-1f4e-11e5-b0dc-0050569b3c3c</otherId>
+    <tag>Project : Rumsey : AtlasProto</tag>
+    <tag>Remediated By : 4.21.4</tag>
+  </identityMetadata>
+  <contentMetadata objectId="cg767mn6478" type="image">
+    <resource id="cg767mn6478_1" sequence="1" type="image">
+      <label>Image 1</label>
+      <file id="2542A.jp2" mimetype="image/jp2" size="5789764">
+        <imageData width="6475" height="4747"/>
+      </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <copyright>
+      <human type="copyright">Property rights reside with the repository, Copyright © Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license. </human>
+    </copyright>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu. </human>
+    </use>
+    <use>
+      <machine type="creativeCommons">by-nc-sa</machine>
+      <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+    </use>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:cg767mn6478">
+      <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>(Covers to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</dc:title>
+    <dc:title>Cover: Carey's American atlas.</dc:title>
+    <dc:contributor>Carey, Mathew (author)</dc:contributor>
+    <dc:type>Covers</dc:type>
+    <dc:type>Book covers</dc:type>
+    <dc:date>1795</dc:date>
+    <dc:publisher>Mathew Carey</dc:publisher>
+    <dc:language>eng</dc:language>
+    <dc:format>37 x 24 cm</dc:format>
+    <dc:format>image/jpeg</dc:format>
+    <dc:coverage>United States</dc:coverage>
+    <dc:coverage>E1200000 W0300000 N0760000 S0590000</dc:coverage>
+    <dc:identifier>2542A</dc:identifier>
+    <dc:identifier>2542A</dc:identifier>
+    <dc:relation type="collection">David Rumsey Map Collection at Stanford University Libraries</dc:relation>
+  </oai_dc:dc>
+  <releaseData>
+    <release to="Searchworks">false</release>
+  </releaseData>
+</publicObject>

--- a/spec/fixtures/document_cache/cg/767/mn/6478/rightsMetadata
+++ b/spec/fixtures/document_cache/cg/767/mn/6478/rightsMetadata
@@ -1,0 +1,22 @@
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">Property rights reside with the repository, Copyright &#xA9; Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license. </human>
+  </copyright>
+  <access type="discover">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu. </human>
+  </use>
+  <use>
+    <machine type="creativeCommons">by-nc-sa</machine>
+    <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+  </use>
+</rightsMetadata>

--- a/spec/fixtures/document_cache/hj/097/bm/8879/contentMetadata
+++ b/spec/fixtures/document_cache/hj/097/bm/8879/contentMetadata
@@ -1,0 +1,10 @@
+<contentMetadata objectId="hj097bm8879" type="map">
+  <resource id="hj097bm8879_1" sequence="1" type="image">
+    <externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1"/>
+    <relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+  </resource>
+  <resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+    <externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1"/>
+    <relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+  </resource>
+</contentMetadata>

--- a/spec/fixtures/document_cache/hj/097/bm/8879/dc
+++ b/spec/fixtures/document_cache/hj/097/bm/8879/dc
@@ -1,0 +1,34 @@
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+   <dc:title>Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</dc:title>
+   <dc:contributor>Carey, Mathew.</dc:contributor>
+   <dc:contributor>Barker, W.</dc:contributor>
+   <dc:contributor>Doolittle, Amos.</dc:contributor>
+   <dc:contributor>Harris, Caleb &amp; Harding.</dc:contributor>
+   <dc:contributor>Harrison, Junr.</dc:contributor>
+   <dc:contributor>Lewis, Samuel.</dc:contributor>
+   <dc:contributor>Scott, J.T.</dc:contributor>
+   <dc:contributor>Smith, Genl. D.</dc:contributor>
+   <dc:contributor>Smither, T.</dc:contributor>
+   <dc:contributor>Vallance.</dc:contributor>
+   
+   <dc:type>map</dc:type>
+   <dc:type>cartographic image</dc:type>
+   <dc:type>Atlases.</dc:type>
+   <dc:date>1795</dc:date>
+   <dc:date>1795.</dc:date><dc:publisher>Mathew Carey,</dc:publisher>
+   <dc:language>eng</dc:language>
+   <dc:format>1 atlas : 21 maps ; 37 x 24 cm</dc:format><dc:format>cartographic material</dc:format>
+   
+   <dc:description>First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's Geography improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas -see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.</dc:description>
+   <dc:description>National Atlas.</dc:description>
+   <dc:description>References: P1172; Walsh p33; NMM 480; Howes C135.</dc:description>
+   <dc:description type="local" displayLabel="Local note">Pub list no.: 2542.000.</dc:description>
+   <dc:subject>Maps</dc:subject><dc:coverage>Western Hemisphere</dc:coverage>
+   <dc:coverage>North America</dc:coverage>
+   <dc:coverage>South America</dc:coverage>
+   <dc:coverage>United States</dc:coverage>
+   <dc:coverage>Canada</dc:coverage>
+   <dc:subject>G1100 1795 .C3 F</dc:subject>
+   <dc:identifier>http://www.davidrumsey.com/luna/servlet/view/search?QuickSearchA=QuickSearchA&amp;q=2542.000&amp;sort=pub_list_no_initialsort%2Cpub_date%2Cpub_list_no%2Cseries_no&amp;search=Search</dc:identifier>
+   
+<dc:relation type="collection">David Rumsey Map Collection at Stanford University Libraries</dc:relation></oai_dc:dc>

--- a/spec/fixtures/document_cache/hj/097/bm/8879/identityMetadata
+++ b/spec/fixtures/document_cache/hj/097/bm/8879/identityMetadata
@@ -1,0 +1,11 @@
+<identityMetadata>
+  <sourceId source="Rumsey"> 2542</sourceId>
+  <objectId>druid:hj097bm8879</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Rumsey Atlas 2542</objectLabel>
+  <objectType>item</objectType>
+  <otherId name="catkey">10449093</otherId>
+  <otherId name="uuid">3526ef90-1f4b-11e5-b0dc-0050569b3c3c</otherId>
+  <tag>Project : Rumsey : AtlasProto</tag>
+  <tag>Remediated By : 4.21.0</tag>
+</identityMetadata>

--- a/spec/fixtures/document_cache/hj/097/bm/8879/mods
+++ b/spec/fixtures/document_cache/hj/097/bm/8879/mods
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+  <titleInfo>
+    <title>Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</title>
+  </titleInfo>
+  <name type="personal" usage="primary">
+    <namePart>Carey, Mathew.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Barker, W.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Doolittle, Amos.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Harris, Caleb &amp; Harding.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Harrison, Junr.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Lewis, Samuel.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Scott, J.T.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Smith, Genl. D.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Smither, T.</namePart>
+  </name>
+  <name type="personal">
+    <namePart>Vallance.</namePart>
+  </name>
+  <typeOfResource>cartographic</typeOfResource>
+  <genre authority="marcgt">map</genre>
+  <genre authority="rdacontent">cartographic image</genre>
+  <genre authority="lcgft">Atlases.</genre>
+  <originInfo>
+    <place>
+      <placeTerm type="code" authority="marccountry">pau</placeTerm>
+    </place>
+    <dateIssued encoding="marc">1795</dateIssued>
+    <issuance>monographic</issuance>
+  </originInfo>
+  <originInfo displayLabel="publisher">
+    <place>
+      <placeTerm>Philadelphia :</placeTerm>
+    </place>
+    <publisher>Mathew Carey,</publisher>
+    <dateIssued>1795.</dateIssued>
+  </originInfo>
+  <language>
+    <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+  </language>
+  <physicalDescription>
+    <form authority="gmd">cartographic material</form>
+    <form authority="marccategory">map</form>
+    <form authority="marcsmd">map</form>
+    <extent>1 atlas : 21 maps ; 37 x 24 cm</extent>
+    <form type="media" authority="rdamedia">unmediated</form>
+    <form type="carrier" authority="rdacarrier">volume</form>
+  </physicalDescription>
+  <note type="statement of responsibility" altRepGroup="00"/>
+  <note>First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's Geography improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas -see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.</note>
+  <note>National Atlas.</note>
+  <note>References: P1172; Walsh p33; NMM 480; Howes C135.</note>
+  <note type="local" displayLabel="Local note">Pub list no.: 2542.000.</note>
+  <subject authority="lcsh">
+    <geographic>Western Hemisphere</geographic>
+    <topic>Maps</topic>
+    <genre>Early works to 1800</genre>
+  </subject>
+  <subject authority="lcsh">
+    <geographic>North America</geographic>
+    <genre>Maps</genre>
+    <genre>Early works to 1800</genre>
+  </subject>
+  <subject authority="lcsh">
+    <geographic>South America</geographic>
+    <genre>Maps</genre>
+    <genre>Early works to 1800</genre>
+  </subject>
+  <subject authority="lcsh">
+    <geographic>United States</geographic>
+    <genre>Maps</genre>
+    <genre>Early works to 1800</genre>
+  </subject>
+  <subject authority="lcsh">
+    <geographic>Canada</geographic>
+    <genre>Maps</genre>
+    <genre>Early works to 1800</genre>
+  </subject>
+  <classification authority="lcc">G1100 1795 .C3 F</classification>
+  <location>
+    <url displayLabel="electronic resource" usage="primary display">http://www.davidrumsey.com/luna/servlet/view/search?QuickSearchA=QuickSearchA&amp;q=2542.000&amp;sort=pub_list_no_initialsort%2Cpub_date%2Cpub_list_no%2Cseries_no&amp;search=Search</url>
+  </location>
+  <recordInfo>
+    <recordContentSource authority="marcorg">CSt</recordContentSource>
+    <recordCreationDate encoding="marc">140415</recordCreationDate>
+    <recordChangeDate encoding="iso8601">20150620011627.0</recordChangeDate>
+    <recordIdentifier source="SIRSI">a10449093</recordIdentifier>
+    <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>
+    <languageOfCataloging>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+    </languageOfCataloging>
+  </recordInfo>
+  <relatedItem type="host">
+    <titleInfo>
+      <title>David Rumsey Map Collection at Stanford University Libraries</title>
+    </titleInfo>
+    <identifier type="uri">http://purl.stanford.edu/xh235dd9059</identifier>
+    <typeOfResource collection="yes"/>
+  </relatedItem>
+  <accessCondition type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu.</accessCondition>
+  <accessCondition type="copyright">Property rights reside with the repository, Copyright © Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.</accessCondition>
+  <accessCondition type="license">CC by-nc-sa: Attribution Non-Commercial Share Alike 3.0 Unported</accessCondition>
+</mods>

--- a/spec/fixtures/document_cache/hj/097/bm/8879/public
+++ b/spec/fixtures/document_cache/hj/097/bm/8879/public
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<publicObject id="druid:hj097bm8879" published="2015-09-09T13:33:17-07:00">
+	<identityMetadata>
+		<sourceId source="Rumsey">2542</sourceId>
+		<objectId>druid:hj097bm8879</objectId>
+		<objectCreator>DOR</objectCreator>
+		<objectLabel>Rumsey Atlas 2542</objectLabel>
+		<objectType>item</objectType>
+		<otherId name="catkey">10449093</otherId>
+		<otherId name="uuid">3526ef90-1f4b-11e5-b0dc-0050569b3c3c</otherId>
+		<tag>Project : Rumsey : AtlasProto</tag>
+		<tag>Remediated By : 4.21.0</tag>
+		<release to="Searchworks">true</release>
+	</identityMetadata>
+	<contentMetadata objectId="hj097bm8879" type="map">
+		<resource id="hj097bm8879_1" sequence="1" type="image">
+			<label>(Covers to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</label>
+			<externalFile fileId="2542A.jp2" objectId="druid:cg767mn6478" resourceId="cg767mn6478_1" mimetype="image/jp2">
+				<imageData width="6475" height="4747"/>
+			</externalFile>
+			<relationship objectId="druid:cg767mn6478" type="alsoAvailableAs"/>
+		</resource>
+		<resource id="hj097bm8879_2" sequence="2" thumb="yes" type="image">
+			<label>(Title Page to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</label>
+			<externalFile fileId="2542B.jp2" objectId="druid:jw923xn5254" resourceId="jw923xn5254_1" mimetype="image/jp2">
+				<imageData width="3139" height="4675"/>
+			</externalFile>
+			<relationship objectId="druid:jw923xn5254" type="alsoAvailableAs"/>
+		</resource>
+	</contentMetadata>
+	<rightsMetadata>
+		<copyright>
+			<human type="copyright">
+Property rights reside with the repository, Copyright &#xA9; Stanford University. Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.
+</human>
+		</copyright>
+		<access type="discover">
+			<machine>
+				<world/>
+			</machine>
+		</access>
+		<access type="read">
+			<machine>
+				<world/>
+			</machine>
+		</access>
+		<use>
+			<human type="useAndReproduction">
+To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu.
+</human>
+		</use>
+		<use>
+			<machine type="creativeCommons">by-nc-sa</machine>
+			<human type="creativeCommons">
+Attribution Non-Commercial Share Alike 3.0 Unported
+</human>
+		</use>
+	</rightsMetadata>
+	<rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+		<rdf:Description rdf:about="info:fedora/druid:hj097bm8879">
+			<fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+			<fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+		</rdf:Description>
+	</rdf:RDF>
+	<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+		<dc:title>
+Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]
+</dc:title>
+		<dc:contributor>Carey, Mathew.</dc:contributor>
+		<dc:contributor>Barker, W.</dc:contributor>
+		<dc:contributor>Doolittle, Amos.</dc:contributor>
+		<dc:contributor>Harris, Caleb &amp; Harding.</dc:contributor>
+		<dc:contributor>Harrison, Junr.</dc:contributor>
+		<dc:contributor>Lewis, Samuel.</dc:contributor>
+		<dc:contributor>Scott, J.T.</dc:contributor>
+		<dc:contributor>Smith, Genl. D.</dc:contributor>
+		<dc:contributor>Smither, T.</dc:contributor>
+		<dc:contributor>Vallance.</dc:contributor>
+		<dc:type>map</dc:type>
+		<dc:type>cartographic image</dc:type>
+		<dc:type>Atlases.</dc:type>
+		<dc:date>1795</dc:date>
+		<dc:date>1795.</dc:date>
+		<dc:publisher>Mathew Carey,</dc:publisher>
+		<dc:language>eng</dc:language>
+		<dc:format>1 atlas : 21 maps ; 37 x 24 cm</dc:format>
+		<dc:format>cartographic material</dc:format>
+		<dc:description>
+First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's Geography improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas -see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.
+</dc:description>
+		<dc:description>National Atlas.</dc:description>
+		<dc:description>References: P1172; Walsh p33; NMM 480; Howes C135.</dc:description>
+		<dc:description type="local" displayLabel="Local note">Pub list no.: 2542.000.</dc:description>
+		<dc:subject>Maps</dc:subject>
+		<dc:coverage>Western Hemisphere</dc:coverage>
+		<dc:coverage>North America</dc:coverage>
+		<dc:coverage>South America</dc:coverage>
+		<dc:coverage>United States</dc:coverage>
+		<dc:coverage>Canada</dc:coverage>
+		<dc:subject>G1100 1795 .C3 F</dc:subject>
+		<dc:identifier>
+http://www.davidrumsey.com/luna/servlet/view/search?QuickSearchA=QuickSearchA&amp;q=2542.000&amp;sort=pub_list_no_initialsort%2Cpub_date%2Cpub_list_no%2Cseries_no&amp;search=Search
+</dc:identifier>
+		<dc:relation type="collection">
+David Rumsey Map Collection at Stanford University Libraries
+</dc:relation>
+	</oai_dc:dc>
+	<releaseData>
+		<release to="Searchworks">true</release>
+	</releaseData>
+</publicObject>

--- a/spec/fixtures/document_cache/hj/097/bm/8879/rightsMetadata
+++ b/spec/fixtures/document_cache/hj/097/bm/8879/rightsMetadata
@@ -1,0 +1,22 @@
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">Property rights reside with the repository, Copyright &#xA9; Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license. </human>
+  </copyright>
+  <access type="discover">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu. </human>
+  </use>
+  <use>
+    <machine type="creativeCommons">by-nc-sa</machine>
+    <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+  </use>
+</rightsMetadata>

--- a/spec/fixtures/document_cache/jw/923/xn/5254/contentMetadata
+++ b/spec/fixtures/document_cache/jw/923/xn/5254/contentMetadata
@@ -1,0 +1,15 @@
+<contentMetadata objectId="jw923xn5254" type="image">
+  <resource id="jw923xn5254_1" sequence="1" type="image">
+    <label>Image 1</label>
+    <file id="2542B.tif" preserve="yes" publish="no" shelve="no" mimetype="image/tiff" size="44028890">
+      <checksum type="md5">b5f6fcd6eb0ad02800aeb82cba6d0eed</checksum>
+      <checksum type="sha1">a90aea983620238d8e1384d9a5cb683c6acd6984</checksum>
+      <imageData width="3139" height="4675"/>
+    </file>
+    <file id="2542B.jp2" mimetype="image/jp2" size="2762668" preserve="no" publish="yes" shelve="yes">
+      <checksum type="md5">bccdbb2500bb139d6d622321bfd2aa57</checksum>
+      <checksum type="sha1">80454c111675ec7e2c425e909810c49a69ffef26</checksum>
+      <imageData width="3139" height="4675"/>
+    </file>
+  </resource>
+</contentMetadata>

--- a/spec/fixtures/document_cache/jw/923/xn/5254/dc
+++ b/spec/fixtures/document_cache/jw/923/xn/5254/dc
@@ -1,0 +1,19 @@
+<oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+        <dc:type>Text</dc:type>
+        <dc:title>(Title Page to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</dc:title>
+    <dc:title>Title Page: Carey's American atlas.</dc:title>
+    <dc:contributor>Carey, Mathew (author)</dc:contributor>    
+                            <dc:type>Title Page</dc:type>
+        <dc:type>title pages</dc:type>
+        
+    <dc:date>1795</dc:date><dc:publisher>Mathew Carey</dc:publisher>
+    <dc:language>eng</dc:language>
+    <dc:format>37 x 23 cm</dc:format><dc:format>image/jpeg</dc:format>
+        <dc:description>First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas - see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.</dc:description>
+                    <dc:coverage>United States</dc:coverage>
+                    <dc:coverage>E1200000 W0300000 N0760000 S0590000</dc:coverage>
+        
+    <dc:identifier>2542B</dc:identifier>
+    <dc:identifier>2542B</dc:identifier>
+    
+<dc:relation type="collection">David Rumsey Map Collection at Stanford University Libraries</dc:relation></oai_dc:dc>

--- a/spec/fixtures/document_cache/jw/923/xn/5254/identityMetadata
+++ b/spec/fixtures/document_cache/jw/923/xn/5254/identityMetadata
@@ -1,0 +1,11 @@
+<identityMetadata>
+  <sourceId source="Rumsey">2542B</sourceId>
+  <objectId>druid:jw923xn5254</objectId>
+  <objectCreator>DOR</objectCreator>
+  <objectLabel>Title Page: Carey's American atlas.</objectLabel>
+  <objectType>item</objectType>
+  <otherId name="label"/>
+  <otherId name="uuid">80698a64-1f4e-11e5-9f88-0050569b3c3c</otherId>
+  <tag>Project : Rumsey : AtlasProto</tag>
+  <tag>Remediated By : 4.21.4</tag>
+</identityMetadata>

--- a/spec/fixtures/document_cache/jw/923/xn/5254/mods
+++ b/spec/fixtures/document_cache/jw/923/xn/5254/mods
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-5.xsd" version="3.5">
+  <typeOfResource>text</typeOfResource>
+  <titleInfo>
+    <title>(Title Page to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</title>
+  </titleInfo>
+  <titleInfo type="alternative" displayLabel="Short title">
+    <title>Title Page: Carey's American atlas.</title>
+  </titleInfo>
+  <name type="personal" usage="primary">
+    <namePart>Carey, Mathew</namePart>
+    <role>
+      <roleTerm type="text" authority="marcrelator">author</roleTerm>
+    </role>
+  </name>
+  <genre>Title Page</genre>
+  <genre authority="aat" valueURI="http://vocab.getty.edu/aat/300055033">title pages</genre>
+  <originInfo eventType="publication">
+    <place>
+      <placeTerm type="text">Philadelphia</placeTerm>
+    </place>
+    <publisher>Mathew Carey</publisher>
+    <dateIssued encoding="w3cdtf" keyDate="yes">1795</dateIssued>
+  </originInfo>
+  <language>
+    <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+  </language>
+  <physicalDescription>
+    <extent>37 x 23 cm</extent>
+    <digitalOrigin>reformatted digital</digitalOrigin>
+    <internetMediaType>image/jpeg</internetMediaType>
+  </physicalDescription>
+  <note>First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas - see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.</note>
+  <subject displayLabel="Country">
+    <geographic>United States</geographic>
+  </subject>
+  <subject>
+    <cartographics>
+      <coordinates>E1200000 W0300000 N0760000 S0590000</coordinates>
+    </cartographics>
+  </subject>
+  <relatedItem type="host" displayLabel="Appears in">
+    <titleInfo>
+      <title>Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</title>
+    </titleInfo>
+    <originInfo eventType="publication">
+      <dateIssued>1795</dateIssued>
+    </originInfo>
+    <identifier type="local" displayLabel="Pub list no.">2542</identifier>
+  </relatedItem>
+  <identifier type="local" displayLabel="List number">2542B</identifier>
+  <identifier type="local" displayLabel="Image number">2542B</identifier>
+  <recordInfo>
+    <languageOfCataloging>
+      <languageTerm authority="iso639-2b">eng</languageTerm>
+    </languageOfCataloging>
+    <recordContentSource authority="marcorg">CSt</recordContentSource>
+  </recordInfo>
+  <relatedItem type="host">
+    <titleInfo>
+      <title>David Rumsey Map Collection at Stanford University Libraries</title>
+    </titleInfo>
+    <identifier type="uri">http://purl.stanford.edu/xh235dd9059</identifier>
+    <typeOfResource collection="yes"/>
+  </relatedItem>
+  <accessCondition type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu.</accessCondition>
+  <accessCondition type="copyright">Property rights reside with the repository, Copyright © Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.</accessCondition>
+  <accessCondition type="license">CC by-nc-sa: Attribution Non-Commercial Share Alike 3.0 Unported</accessCondition>
+</mods>

--- a/spec/fixtures/document_cache/jw/923/xn/5254/public
+++ b/spec/fixtures/document_cache/jw/923/xn/5254/public
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:jw923xn5254" published="2015-10-23T19:41:15-07:00" publishVersion="dor-services/4.22.3">
+  <identityMetadata>
+    <sourceId source="Rumsey">2542B</sourceId>
+    <objectId>druid:jw923xn5254</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>Title Page: Carey's American atlas.</objectLabel>
+    <objectType>item</objectType>
+    <otherId name="label"/>
+    <otherId name="uuid">80698a64-1f4e-11e5-9f88-0050569b3c3c</otherId>
+    <tag>Project : Rumsey : AtlasProto</tag>
+    <tag>Remediated By : 4.21.4</tag>
+  </identityMetadata>
+  <contentMetadata objectId="jw923xn5254" type="image">
+    <resource id="jw923xn5254_1" sequence="1" type="image">
+      <label>Image 1</label>
+      <file id="2542B.jp2" mimetype="image/jp2" size="2762668">
+        <imageData width="3139" height="4675"/>
+      </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <copyright>
+      <human type="copyright">Property rights reside with the repository, Copyright © Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license. </human>
+    </copyright>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu. </human>
+    </use>
+    <use>
+      <machine type="creativeCommons">by-nc-sa</machine>
+      <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+    </use>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:jw923xn5254">
+      <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:type>Text</dc:type>
+    <dc:title>(Title Page to) Carey's American Atlas: Containing Twenty Maps And One Chart ... Philadelphia: Engraved For, And Published By, Mathew Carey, No. 118, Market Street. M.DCC.XCV. [Price, Plain, Five Dollars-Coloured, Six Dollars.]</dc:title>
+    <dc:title>Title Page: Carey's American atlas.</dc:title>
+    <dc:contributor>Carey, Mathew (author)</dc:contributor>
+    <dc:type>Title Page</dc:type>
+    <dc:type>title pages</dc:type>
+    <dc:date>1795</dc:date>
+    <dc:publisher>Mathew Carey</dc:publisher>
+    <dc:language>eng</dc:language>
+    <dc:format>37 x 23 cm</dc:format>
+    <dc:format>image/jpeg</dc:format>
+    <dc:description>First atlas of America printed in America. First edition. These maps were also published in Carey's American edition of Guthrie's Geography (1795) and most of the maps say "engraved for Carey's American edition of Guthrie's improved." The maps were again used for the 1796 edition of Carey's General Atlas, unchanged except for the Tennessee map, which is titled "Tennassee State" instead of "Tennassee Government" which is the title in both the American Atlas and the Guthrie Atlas - see Wheat and Brun, and has several counties delineated in the eastern part of the state which do not show in the 1795 edition of the map. NMM 480 (American Atlas) has "Tennassee State" indicating that Carey was not consistent. This atlas was the model for John Reid's American Atlas of 1796. This copy's maps have very strong impressions. Rebound quarter leather, marbled paper covered boards.</dc:description>
+    <dc:coverage>United States</dc:coverage>
+    <dc:coverage>E1200000 W0300000 N0760000 S0590000</dc:coverage>
+    <dc:identifier>2542B</dc:identifier>
+    <dc:identifier>2542B</dc:identifier>
+    <dc:relation type="collection">David Rumsey Map Collection at Stanford University Libraries</dc:relation>
+  </oai_dc:dc>
+  <releaseData>
+    <release to="Searchworks">false</release>
+  </releaseData>
+</publicObject>

--- a/spec/fixtures/document_cache/jw/923/xn/5254/rightsMetadata
+++ b/spec/fixtures/document_cache/jw/923/xn/5254/rightsMetadata
@@ -1,0 +1,22 @@
+<rightsMetadata>
+  <copyright>
+    <human type="copyright">Property rights reside with the repository, Copyright &#xA9; Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license. </human>
+  </copyright>
+  <access type="discover">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <access type="read">
+    <machine>
+      <world/>
+    </machine>
+  </access>
+  <use>
+    <human type="useAndReproduction">To obtain permission to publish or reproduce commercially, please contact the Digital &amp; Rare Map Librarian, David Rumsey Map Center at rumseymapcenter@stanford.edu. </human>
+  </use>
+  <use>
+    <machine type="creativeCommons">by-nc-sa</machine>
+    <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+  </use>
+</rightsMetadata>


### PR DESCRIPTION
This PR implements virtual object support for IIIF manifests. See issue #49 for details.

@cbeer @tingulfsen I'd like to pair up to review this PR as my testing was limited to my laptop and I did not deploy to the -dev or -test environments.

Note the Travis build is failing whereas my local instance passes all specs. I did run into configuration issues as my virtual object fixture data is not in the -prod or -test environment (which may be why Travis is failing if it's trying to fetch public XML data from outside the fixtures directory) but I was able to change my local configuration to work solely off my laptop for testing it. I've added 3 new feature tests for 2 child objects and the parent virtual object.

```
IIIF manifests
  works
  includes a representative thumbnail
  includes authorization services for a Stanford-only image
  suppresses sequences for dark resources
  virtual objects
    works for the first child object
    works for the second child object
    works for the parent object
```