### PR TITLE
Remove primary/secondary mods name helpers and loop through all in…

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -42,24 +42,6 @@ module RecordHelper
     mods_display_label(field.label) + mods_display_name(field.values)
   end
 
-  def mods_primary_names(names)
-    names.map do |name|
-      if name.label == 'Author/Creator'
-        name
-      elsif names_include_primary?(name)
-        OpenStruct.new(label: name.label, values: name.values.select { |n| roles_include_primary?(n) })
-      end
-    end.compact
-  end
-
-  def mods_secondary_names(names)
-    names.map do |name|
-      if name.label != 'Author/Creator' && !names_include_primary?(name)
-        OpenStruct.new(label: name.label, values: name.values.reject { |n| roles_include_primary?(n) })
-      end
-    end.compact
-  end
-
   def mods_display_name(names)
     names.map do |name|
       content_tag(:dd) do
@@ -128,18 +110,4 @@ module RecordHelper
     val
   end
   # rubocop:enable Metrics/LineLength
-
-  private
-
-  def names_include_primary?(names)
-    names.values.any? do |name|
-      roles_include_primary?(name)
-    end
-  end
-
-  def roles_include_primary?(name)
-    return false unless name.roles.present?
-
-    name.roles.include?('Author') || name.roles.include?('Creator')
-  end
 end

--- a/app/views/purl/_mods_contributors.html.erb
+++ b/app/views/purl/_mods_contributors.html.erb
@@ -1,9 +1,7 @@
 <% document ||= @document %>
 
-<% mods_primary_names(document.mods.name).each do |name| %>
-  <%= mods_name_field(name) %>
-<% end %>
-
-<% mods_secondary_names(document.mods.name).each do |name| %>
-  <%= mods_name_field(name) %>
+<% if document.mods.name.present? %>
+  <% document.mods.name.each do |name| %>
+    <%= mods_name_field(name) %>
+  <% end %>
 <% end %>

--- a/app/views/purl/_mods_metadata_sections.html.erb
+++ b/app/views/purl/_mods_metadata_sections.html.erb
@@ -23,7 +23,7 @@
 <% if contributors.present? %>
   <div class="section" id="<%= t('record_side_nav.contributors.id') %>" data-side-nav-class="<%= t('record_side_nav.contributors.id') %>">
     <div class="section-heading">
-      <h2><%= t('record_side_nav.contributors.icon').html_safe %> Contributors</h2>
+      <h2><%= t('record_side_nav.contributors.icon').html_safe %> Creators/Contributors</h2>
     </div>
     <div class="section-body">
       <dl>


### PR DESCRIPTION
… contributors section.

This is causing certain contributors to not be displayed (see "Morin, Andre" in jw402xz0487).

SearchWorks has unified all contributors into a re-labeled Creators/Contributors section.