### PR TITLE
okcomputer now mounted at /status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,10 @@ gem 'cancancan', '~> 1.10'
 # Use Honeybadger for exception reporting
 gem 'honeybadger'
 
-# Use is_it_working to monitor the application
+# Use okcomputer to monitor the application
+gem 'okcomputer'
+# TODO: remove is_it_working after load balancer and nagios are switched to okcomputer mount point
+# Use is_it_working to monitor the application -
 gem 'is_it_working'
 
 gem 'mods_display', '~> 0.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
+    okcomputer (1.11.1)
     parser (2.3.1.2)
       ast (~> 2.2)
     pkg-config (1.1.7)
@@ -335,6 +336,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   mods_display (~> 0.3.2)
+  okcomputer
   poltergeist
   rails (= 4.2.7.1)
   rails-file-icons

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,105 @@
+require 'okcomputer'
+
+# /status for 'upness', e.g. for load balancer
+# /status/all to show all dependencies
+# /status/<name-of-check> for a specific check (e.g. for nagios warning)
+OkComputer.mount_at = 'status'
+OkComputer.check_in_parallel = true
+OkComputer::Registry.deregister "database" # don't check (unused) ActiveRecord database conn
+
+# TODO: remove DirectoryCheck here after there is comparable functionality in okcomputer
+class DirectoryCheck < OkComputer::Check
+  attr_reader :path, :options
+  def initialize(path, options = {})
+    @path = Pathname(path.to_s)
+    @options = options
+  end
+
+  def check
+    mark_message "Directory check for #{path}: #{options.inspect}"
+    mark_failure if options[:read] && !path.readable?
+    mark_failure if options[:write] && !path.writable?
+  end
+end
+
+# Check if a mail server is responding.
+# TODO: remove ActionMailerCheck here after there is comparable functionality in okcomputer
+class ActionMailerCheck < OkComputer::Check
+  attr_reader :klass, :timeout_secs
+  def initialize(klass, timeout_secs = 2)
+    @klass = klass || ActionMailer::Base
+    @timeout_secs = timeout_secs
+  end
+  def check
+    host = klass.smtp_settings[:address]
+    port = klass.smtp_settings[:port] || 'smtp'
+    begin
+      ping(host, port, timeout_secs)
+      mark_message "#{klass} is accepting connections on port #{port}"
+    rescue Errno::ECONNREFUSED
+      mark_message "#{klass} is not accepting connections on port #{port}"
+      mark_failure
+    rescue SocketError => e
+      mark_message "connection to #{klass} on port #{port} failed with '#{e.message}'"
+      mark_failure
+    rescue TimeoutError
+      mark_message "#{klass} did not respond on port #{port} within #{timeout_secs} seconds"
+      mark_failure
+    rescue e
+      mark_message "connection to #{klass} on port #{port} failed with '#{e.message}'"
+      mark_failure
+    end
+  end
+
+  def ping(host, port, timeout_secs)
+    timeout(timeout_secs) do
+      s = TCPSocket.new(host, port)
+      s.close
+    end
+    true
+  end
+end
+
+# REQUIRED checks, part of /status/all
+OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new
+
+OkComputer::Registry.register 'document_cache_root',
+  DirectoryCheck.new(Settings.document_cache_root, read: true, write: true)
+
+# Check the memcache servers used by Rails.cache
+# FIXME:  bug in CacheCheck makes this check meaningless unless cache responds to stats (DalliStore does)
+if Rails.cache.respond_to? :stats
+  OkComputer::Registry.register 'rails_cache', OkComputer::CacheCheck.new
+else
+  OkComputer::Registry.register 'rails_cache', OkComputer::GenericCacheCheck.new
+end
+
+# NOTE:
+# Settings.purl_resource.public_xml, Settings.purl_resource.mods, and Settings.purl_resource.iiif_manifest
+# exist in the document cache root on deployed environments.
+# The document cache root check should be sufficient for these.
+
+# NOTE: Settings.stacks.iiif_profile is a static service to tell services what renderer to use for IIIF
+#  and therefore doesn't need to be considered a dependency here
+
+# ------------------------------------------------------------------------------
+
+# NON-CRUCIAL checks, avail at /status/<name-of-check>
+#   in /status/all, Optional checks will always return status success;
+#   at individual endpoint they show true results
+OkComputer::Registry.register 'stacks_service', OkComputer::HttpCheck.new(Settings.stacks.url)
+
+# OEmbed service
+TEST_DRUID = 'pv954fv1448' # in both purl/stacks prod and purl/stacks test
+resource_url = Settings.embed.url.sub('%{druid}', TEST_DRUID)
+OkComputer::Registry.register 'embed_service',
+  OkComputer::HttpCheck.new(Settings.embed.iframe.url_template.sub('{?url*}', "?url=#{resource_url}"))
+
+OkComputer::Registry.register 'feedback_mailer', ActionMailerCheck.new(FeedbackMailer)
+
+# TODO: When SW has a more benign endpoint for up-ness checks, we should use that.
+#  For now, concerned about hammering SearchWorks with pings, as these will all hit the Solr index.
+#  This is minor functionality for purl -- "View in SearchWorks" link
+#OkComputer::Registry.register 'searchworks', OkComputer::HttpCheck.new("#{Settings.searchworks.url}#{TEST_DRUID}")
+
+OkComputer.make_optional %w(stacks_service embed_service feedback_mailer)

--- a/spec/integration/purl_spec.rb
+++ b/spec/integration/purl_spec.rb
@@ -118,4 +118,22 @@ describe 'purl', type: :feature do
       expect(page).to have_text('OK')
     end
   end
+
+  describe '/status' do
+    it 'has response code 200' do
+      visit '/status'
+      expect(page.status_code).to eq 200
+      expect(page).to have_text('Application is running')
+    end
+    it '/status/all has response code 200' do
+      visit '/status/all'
+      expect(page.status_code).to eq 200
+      expect(page).to have_text('HTTP check successful')
+    end
+    it '/status/feedback_mailer responds' do
+      visit '/status/feedback_mailer'
+      expect(page.status_code).to eq 200
+      expect(page).to have_text('FeedbackMailer')
+    end
+  end
 end


### PR DESCRIPTION
note that for seamless integration without coordinating deploy with load balancer and nagios updates, the code will have both is_it_working and okcomputer temporarily.

You can see this in action:

https://sul-purl-dev.stanford.edu/status
https://sul-purl-dev.stanford.edu/status/all
https://sul-purl-dev.stanford.edu/status/feedback_mailer   (or name of any specific check)

you can put `.json` at the end to get the results in json.


The plan:

- deploy this (after merge) so we can change load balancer and nagios to look for /status instead of /is_it_working
- after LB and nagios aren't dependent on is_it_working, remove it.

connects to #87 
connects to sul-dlss/media#125