### PR TITLE
okcomputer: use GenericCacheCheck always as CacheCheck won't pass

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -68,11 +68,7 @@ OkComputer::Registry.register 'document_cache_root',
   DirectoryCheck.new(Settings.document_cache_root, read: true, write: true)
 
 # Check the memcache servers used by Rails.cache
-if Rails.cache.respond_to? :stats
-  OkComputer::Registry.register 'rails_cache', OkComputer::CacheCheck.new
-else
-  OkComputer::Registry.register 'rails_cache', OkComputer::GenericCacheCheck.new
-end
+OkComputer::Registry.register 'rails_cache', OkComputer::GenericCacheCheck.new
 
 # NOTE:
 # Settings.purl_resource.public_xml, Settings.purl_resource.mods, and Settings.purl_resource.iiif_manifest


### PR DESCRIPTION
due to how OkComputer::CacheCheck expects the host name, we can't use it;  always using GenericCacheCheck will ensure that the cache is working;  we just won't get stats used in the result.  No biggie.

Glad I noticed this before I put in for nagios checks!