### PR TITLE
upgrade to honeybadger 2.6.1 to avoid deployment warning 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    honeybadger (2.6.0)
+    honeybadger (2.6.1)
     htmlentities (4.3.4)
     i18n (0.7.0)
     iiif-presentation (0.1.0)


### PR DESCRIPTION
about git set_current_version