### PR TITLE
Allow druids on landing page to be configured per-env so production …

### DIFF
--- a/app/views/purl/index.html.erb
+++ b/app/views/purl/index.html.erb
@@ -25,40 +25,15 @@
   </div>
 </div>
 
+<% if Settings.landing_page_druids.present? %>
 <div class="row">
   <div class="col-md-12">
     <h3>Featured Items</h3>
     <ul>
-      <li><%= link_to_purl("bb000kq3835") %></li>
-      <li><%= link_to_purl("bb112zx3193") %></li>
-      <li><%= link_to_purl("py305sy7961") %></li>
-      <li><%= link_to_purl("bb537hc4022") %></li>
-      <li><%= link_to_purl("cd366rw7886") %></li>
-      <li><%= link_to_purl("bg730rr6720") %></li>
-      <li><%= link_to_purl("bc854fy5899") %></li>
-      <li><%= link_to_purl("mv660ws7416") %></li>
-      <li><%= link_to_purl("bc421tk1152") %></li>
-      <li><%= link_to_purl("bb023ts9016") %></li>
-      <li><%= link_to_purl("bh538xp9013") %></li>
-      <li><%= link_to_purl("bb737zp0787") %></li>
-      <li><%= link_to_purl("dn665vh1697") %></li>
-      <li><%= link_to_purl("bj057dg6517") %></li>
-      <li><%= link_to_purl("fr352bj3947") %></li>
-      <li><%= link_to_purl("bb402bm5087") %></li>
-      <li><%= link_to_purl("cy496ky1984") %></li>
-      <li><%= link_to_purl("nh329xv9953") %></li>
-      <li><%= link_to_purl("mg662qq6088") %></li>
-      <li><%= link_to_purl("km993dd6050") %></li>
-      <li><%= link_to_purl("qz826pn3100") %></li>
-      <li><%= link_to_purl("nd387jf5675") %></li>
-      <li><%= link_to_purl("sy486tp5223") %></li>
-      <li><%= link_to_purl("yx282xq2090") %></li>
-      <li><%= link_to_purl("gx074xz5520") %></li>
-      <li><%= link_to_purl("cz128vq0535") %></li>
-      <li><%= link_to_purl("fp756wn9369") %></li>
-      <li><%= link_to_purl("tg926kp6619") %></li>
-      <li><%= link_to_purl("sf815vr1246") %></li>
-      <li><%= link_to_purl("gb089bd2251") %></li>
+      <% Settings.landing_page_druids.each do |druid| %>
+        <li><%= link_to_purl(druid) %></li>
+      <% end %>
     </ul>
   </div>
 </div>
+<% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -44,6 +44,38 @@ releases:
 searchworks:
   url: 'https://searchworks.stanford.edu/view/'
 
+landing_page_druids:
+  - bb000kq3835
+  - bb112zx3193
+  - py305sy7961
+  - bb537hc4022
+  - cd366rw7886
+  - bg730rr6720
+  - bc854fy5899
+  - mv660ws7416
+  - bc421tk1152
+  - bb023ts9016
+  - bh538xp9013
+  - bb737zp0787
+  - dn665vh1697
+  - bj057dg6517
+  - fr352bj3947
+  - bb402bm5087
+  - cy496ky1984
+  - nh329xv9953
+  - mg662qq6088
+  - km993dd6050
+  - qz826pn3100
+  - nd387jf5675
+  - sy486tp5223
+  - yx282xq2090
+  - gx074xz5520
+  - cz128vq0535
+  - fp756wn9369
+  - tg926kp6619
+  - sf815vr1246
+  - gb089bd2251
+
 feedback:
   email_to: ""
 


### PR DESCRIPTION
…druids don't cause 404 on non-production envs.

Currently sul-purl-dev and sul-purl-test landing pages return a 404 because it is attempting to load a production druid and the `PurlResource::ObjectNotReady` error is raised.

This allows us to simply set the druid list to an empty array (or nil) to remove the section entirely, or we can add environment specific druids to be displayed on the landing page for that environment.


## Before
<img width="1087" alt="before" src="https://cloud.githubusercontent.com/assets/96776/18693438/8777dd92-7f56-11e6-994c-b1ea9c077737.png">

## After
<img width="1094" alt="after" src="https://cloud.githubusercontent.com/assets/96776/18693437/87656ff4-7f56-11e6-8744-f0e975488bce.png">

