### PR TITLE
use cap-shared_configs

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -23,9 +23,10 @@ require 'capistrano/deploy'
 
 require 'capistrano/rails'
 require 'capistrano/passenger'
-require 'dlss/capistrano'
 require 'capistrano/honeybadger'
+require 'capistrano/shared_configs'
 require 'whenever/capistrano'
+require 'dlss/capistrano'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'sul_styles', '~> 0.3'
 gem 'iiif-presentation'
 gem 'dalli'
 gem 'dynamic_sitemaps'
-gem 'whenever'
+gem 'whenever'  # for scheduling sitemap generation
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
@@ -92,9 +92,9 @@ gem 'lograge'
 # Use Capistrano for deployment
 group :deployment do
   gem 'capistrano', '~> 3.0'
-  gem 'capistrano-rvm'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'capistrano-passenger'
+  gem 'capistrano-shared_configs'
   gem 'dlss-capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,9 +76,7 @@ GEM
       capistrano-bundler (~> 1.1)
     capistrano-releaseboard (0.0.1)
       faraday
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
+    capistrano-shared_configs (0.1.1)
     capybara (2.9.0)
       addressable
       mime-types (>= 1.16)
@@ -330,7 +328,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
+  capistrano-shared_configs
   capybara
   codeclimate-test-reporter
   config

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,3 +33,6 @@ set :linked_dirs, %w(config/settings log tmp/pids tmp/cache tmp/sockets vendor/b
 
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
+
+# update shared_configs before restarting app
+before 'deploy:restart', 'shared_configs:update'


### PR DESCRIPTION
to get latest shared_config files with cap deploy.  (shared_config files are coming!  #71, sul-dlss/media#113 )

also stop including unused capistrano/rvm in Gemfile.