### PR TITLE
Use the original_url for the IIIF manifest's @id value.

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -50,7 +50,7 @@ class PurlController < ApplicationController
     return unless stale?(last_modified: @purl.updated_at.utc, etag: @purl.cache_key + "/#{@purl.updated_at.utc}")
 
     if @purl.iiif_manifest?
-      manifest = Rails.cache.fetch([@purl, @purl.updated_at.utc], expires_in: Settings.resource_cache.lifetime) do
+      manifest = Rails.cache.fetch([@purl, params[:format], @purl.updated_at.utc], expires_in: Settings.resource_cache.lifetime) do
         @purl.iiif_manifest.body(self).to_ordered_hash
       end
 

--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -53,7 +53,7 @@ class IiifPresentationManifest
     purl_base_uri = controller.purl_url(druid)
 
     manifest_data = {
-      '@id'   => controller.iiif_manifest_url(druid),
+      '@id'   => controller.request.original_url,
       'label' => title,
       'attribution' => copyright || 'Provided by the Stanford University Libraries',
       'logo' => {

--- a/spec/features/iiif_manifest_spec.rb
+++ b/spec/features/iiif_manifest_spec.rb
@@ -55,6 +55,18 @@ describe 'IIIF manifests' do
     expect(json['metadata']).to eq(expected_dc_metadata)
   end
 
+  it 'has the correct @id value given the url the manifest is being requested under' do
+    visit '/bb157hs6068/iiif/manifest.json'
+    json = JSON.parse(page.body)
+
+    expect(json['@id']).to match %r{/bb157hs6068/iiif/manifest.json$}
+
+    visit '/bb157hs6068/iiif/manifest'
+    json = JSON.parse(page.body)
+
+    expect(json['@id']).to match %r{/bb157hs6068/iiif/manifest$}
+  end
+
   it 'includes a representative thumbnail' do
     visit '/bb157hs6068/iiif/manifest.json'
     json = JSON.parse(page.body)

--- a/spec/model/iiif_presentation_manifest_spec.rb
+++ b/spec/model/iiif_presentation_manifest_spec.rb
@@ -1,8 +1,69 @@
 require 'rails_helper'
 
+class TestPurlController
+  delegate :iiif_manifest_url, :purl_url, to: :helpers
+  delegate :original_url, to: :request
+
+  def initialize
+    Rails.application.routes.default_url_options = default_url_options
+  end
+
+  def request
+    ActionDispatch::Request.new(
+      'ORIGINAL_FULLPATH' => "/abc123/iiif/manifest.#{params[:format]}"
+    )
+  end
+
+  def params
+    {}
+  end
+
+  private
+
+  def default_url_options
+    { host: 'https://example.com' }
+  end
+
+  def helpers
+    Rails.application.routes.url_helpers
+  end
+end
+
 describe IiifPresentationManifest do
   let(:resource) { double }
   subject { described_class.new(resource) }
+
+  describe '@id' do
+    let(:controller) { TestPurlController.new }
+    let(:resource) do
+      double(
+        PurlResource,
+        druid: 'abc123',
+        title: nil,
+        type: nil,
+        copyright: nil,
+        description: nil,
+        content_metadata: double(deliverable_files: []),
+        public_xml_document: Nokogiri::XML('<xml/>')
+      )
+    end
+
+    context 'when requested under json' do
+      before { expect(controller).to receive_messages(params: { format: :json }) }
+
+      it 'returns the current url (includes .json)' do
+        manifest = subject.body(controller)
+        expect(manifest['@id']).to match(%r{/abc123/iiif/manifest.json})
+      end
+    end
+
+    context 'when requested not under json' do
+      it 'returns the current url (does not include .json)' do
+        manifest = subject.body(controller)
+        expect(manifest['@id']).to match(%r{/abc123/iiif/manifest})
+      end
+    end
+  end
 
   describe '#stacks_iiif_base_url' do
     it 'generates IIIF URLs for content metadata resources' do


### PR DESCRIPTION
Fixes #122 