### PR TITLE
Integrate 3D fixture and fake image fixture for mapping

### DIFF
--- a/spec/fixtures/iiif_manifests/v3/3D_hc941fm6529.json
+++ b/spec/fixtures/iiif_manifests/v3/3D_hc941fm6529.json
@@ -1,0 +1,62 @@
+{  
+   "id":"http://dms-data.stanford.edu/data/manifests/v3test/hc941fm6529/manifest.json",
+   "type":"Manifest",
+   "label":"Sheep (Ovis aries), male, cervical vertabra",
+   "attribution":"Provided by the Stanford University Libraries",
+   "logo":{  
+      "@id":"https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg",
+      "service":{  
+         "@context":"http://iiif.io/api/image/2/context.json",
+         "@id":"https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette",
+         "profile":"http://iiif.io/api/image/2/level1.json"
+      }
+   },
+   "seeAlso":{  
+      "@id":"https://purl.stanford.edu/hc941fm6529.mods",
+      "format":"application/mods+xml"
+   },
+   "metadata":[  
+      {  
+         "label":"Title",
+         "value":"Sheep (Ovis aries), male, cervical vertabra"
+      },
+      {  
+         "label":"Everything Else",
+         "value":"Our usual array of dc-derived metadata"
+      }
+   ],
+   "sequences":[  
+      {  
+         "id":"https://purl.stanford.edu/hc941fm6529#sequence-1",
+         "type":"Sequence",
+         "label":"Current order",
+         "canvases":[  
+            {  
+               "id":"https://purl.stanford.edu/hc941fm6529/iiif/canvas/hc941fm6529_1",
+               "type":"Canvas",
+               "label":"3D Test",
+               "content":[  
+                  {  
+                     "id":"https://purl.stanford.edu/hc941fm6529/iiif/annotationpage/hc941fm6529_1",
+                     "type":"AnnotationPage",
+                     "items":[  
+                        {  
+                           "id":"https://purl.stanford.edu/hc941fm6529/iiif/annotation/hc941fm6529_1",
+                           "type":"Annotation",
+                           "motivation":"painting",
+                           "body":{  
+                              "id":"https://stacks.stanford.edu/file/druid:hc941fm6529/hc941fm6529.json",
+                              "type":"PhysicalObject",
+                              "format":"application/vnd.threejs+json",
+							  "label":"Sheep (Ovis aries), male, cervical vertabra"
+                           },
+                           "target":"https://purl.stanford.edu/hc941fm6529/iiif/canvas/hc941fm6529_1"
+                        }
+                     ]
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}

--- a/spec/fixtures/iiif_manifests/v3/image_rf200sq2539.json
+++ b/spec/fixtures/iiif_manifests/v3/image_rf200sq2539.json
@@ -1,0 +1,70 @@
+{  
+   "id":"http://dms-data.stanford.edu/data/manifests/v3test/rf200sq2539/manifest.json",
+   "type":"Manifest",
+   "label":"PC0002_353_poetry_and_prose_scene_at_monument_point_north_end_of_salt_lake",
+   "attribution":"Provided by the Stanford University Libraries",
+   "logo":{  
+      "@id":"https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette/full/400,/0/default.jpg",
+      "service":{  
+         "@context":"http://iiif.io/api/image/2/context.json",
+         "@id":"https://stacks.stanford.edu/image/iiif/wy534zh7137%2FSULAIR_rosette",
+         "profile":"http://iiif.io/api/image/2/level1.json"
+      }
+   },
+   "seeAlso":{  
+      "@id":"https://purl.stanford.edu/rf200sq2539.mods",
+      "format":"application/mods+xml"
+   },
+   "metadata":[  
+      {  
+         "label":"Title",
+         "value":"PC0002_353_poetry_and_prose_scene_at_monument_point_north_end_of_salt_lake"
+      },
+      {  
+         "label":"Everything Else",
+         "value":"Our usual array of dc-derived metadata"
+      }
+   ],
+   "sequences":[  
+      {  
+         "id":"https://purl.stanford.edu/rf200sq2539#sequence-1",
+         "type":"Sequence",
+         "label":"Current order",
+         "canvases":[  
+            {  
+               "id":"https://purl.stanford.edu/rf200sq2539/iiif/canvas/rf200sq2539_1",
+               "type":"Canvas",
+               "width":5860,
+               "height":5027,
+               "label":"Totally Fake Image Test",
+               "content":[  
+                  {  
+                     "id":"https://purl.stanford.edu/rf200sq2539/iiif/annotationpage/rf200sq2539_1",
+                     "type":"AnnotationPage",
+                     "items":[  
+                        {  
+                           "id":"https://purl.stanford.edu/rf200sq2539/iiif/annotation/rf200sq2539_1",
+                           "type":"Annotation",
+                           "motivation":"painting",
+		                   "width":5860,
+		                   "height":5027,
+                           "body":{  
+                              "id":"https://stacks.stanford.edu/image/iiif/rf200sq2539%2FPC0002_356_the_last_rail_is_laid_scene_at_promontory_point_may_10_1869/full/full/0/default.jpg",
+                              "type":"Image",
+                              "format":"image/jpeg",
+							  "service": {
+							  	"@context": "http://iiif.io/api/image/2/context.json",
+							  	"@id": "https://stacks.stanford.edu/image/iiif/rf200sq2539%2FPC0002_356_the_last_rail_is_laid_scene_at_promontory_point_may_10_1869",
+							  	"profile": "http://iiif.io/api/image/2/level1.json"
+							  }
+                           },
+                           "target":"https://purl.stanford.edu/rf200sq2539/iiif/canvas/rf200sq2539_1"
+                        }
+                     ]
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}


### PR DESCRIPTION
Two fixtures. The 3D object follows the UV team's spec. The image object is totally fake - and is just included to provide a mapping between a current image in our 2.0 implementation to an item object for the pre-3.0 UV spec.