### PR TITLE
IIIF v3 manifest requires thumbnails to be an Array

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -37,7 +37,7 @@ class Iiif3PresentationManifest < IiifPresentationManifest
       'label' => 'Current order'
     )
 
-    manifest.thumbnail = thumbnail_resource
+    manifest.thumbnail = [thumbnail_resource]
 
     # for each resource image, create a canvas
     resources.each do |resource|

--- a/spec/features/iiif3_manifest_spec.rb
+++ b/spec/features/iiif3_manifest_spec.rb
@@ -10,7 +10,9 @@ describe 'IIIF v3 manifests' do
     expect(json['description']).to eq 'Tom.1. No.9. (top right).'
     expect(json['attribution']).to start_with 'This work has been identified as being free of known restrictions'
     expect(json['seeAlso']['id']).to eq 'http://www.example.com/bb157hs6068.mods'
-    expect(json['thumbnail']['id']).to eq 'https://stacks.stanford.edu/image/iiif/bb157hs6068%2Fbb157hs6068_05_0001/full/!400,400/0/default.jpg'
+    expect(json['thumbnail']).to be_an Array
+    expect(json['thumbnail'].size).to eq 1
+    expect(json['thumbnail'].first['id']).to eq 'https://stacks.stanford.edu/image/iiif/bb157hs6068%2Fbb157hs6068_05_0001/full/!400,400/0/default.jpg'
 
     expect(json['sequences'].length).to eq 1
     canvas = json['sequences'].first['canvases'].first
@@ -59,8 +61,10 @@ describe 'IIIF v3 manifests' do
     visit '/bb157hs6068/iiif3/manifest'
     json = JSON.parse(page.body)
 
-    expect(json['thumbnail']['id']).to eq 'https://stacks.stanford.edu/image/iiif/bb157hs6068%2Fbb157hs6068_05_0001/full/!400,400/0/default.jpg'
-    expect(json['thumbnail']['type']).to eq 'Image'
+    expect(json['thumbnail']).to be_an Array
+    expect(json['thumbnail'].size).to eq 1
+    expect(json['thumbnail'].first['id']).to eq 'https://stacks.stanford.edu/image/iiif/bb157hs6068%2Fbb157hs6068_05_0001/full/!400,400/0/default.jpg'
+    expect(json['thumbnail'].first['type']).to eq 'Image'
   end
 
   it 'includes authorization services for a Stanford-only image' do
@@ -151,7 +155,9 @@ describe 'IIIF v3 manifests' do
 
         json = JSON.parse(page.body)
         expect(json['label']).to start_with 'Carey\'s American Atlas'
-        expect(json['thumbnail']['id']).to end_with '/image/iiif/cg767mn6478%2F2542A/full/!400,400/0/default.jpg' # first child
+        expect(json['thumbnail']).to be_an Array
+        expect(json['thumbnail'].size).to eq 1
+        expect(json['thumbnail'].first['id']).to end_with '/image/iiif/cg767mn6478%2F2542A/full/!400,400/0/default.jpg' # first child
         expect(json['sequences'].length).to eq 1
         expect(json['sequences'].first['canvases'].length).to eq 23
 

--- a/spec/fixtures/iiif_manifests/v3/image_bx658jh7339.json
+++ b/spec/fixtures/iiif_manifests/v3/image_bx658jh7339.json
@@ -77,7 +77,7 @@
     "label": "PublishDate",
     "value": "2013-12-14T16:51:21-08:00"
   }],
-  "thumbnail": {
+  "thumbnail": [{
     "id": "https://stacks.stanford.edu/image/iiif/bx658jh7339%2FT0000001/full/!400,400/0/default.jpg",
     "type": "dctypes:Image",
     "format": "image/jpeg",
@@ -86,7 +86,7 @@
       "id": "https://stacks.stanford.edu/image/iiif/bx658jh7339%2FT0000001",
       "profile": "http://iiif.io/api/image/2/level1.json"
     }
-  },
+  }],
   "sequences": [{
     "id": "https://purl.stanford.edu/bx658jh7339#sequence-1",
     "type": "Sequence",


### PR DESCRIPTION
closes #171 

from http://prezi3.iiif.io/api/presentation/3.0

```The value must be a JSON array, with each item in the array being a JSON object with at least an id and type property.```

Affirmed that Universal Viewer:
- [x] works with array
- [x] works with id and type properties.


I am presuming that the `iiif3` manifests are only consumed by Universal Viewer;  I did not check that this works with ImageX Viewer ...