### PR TITLE
ignore standard rails config gem locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@
 /tmp
 
 coverage
-config/settings/*
 config/honeybadger.yml
 document_cache/*
+
+# Ignore standard Rails Config Settings
+config/settings.local.yml
+config/settings/*.local.yml
+config/environments/*.local.yml


### PR DESCRIPTION
See https://github.com/railsconfig/config/blob/master/lib/generators/config/install_generator.rb#L23-L28