### PR TITLE
iiif sequence (v2 and v3): populate viewingDirection correctly

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -43,7 +43,7 @@ class Iiif3PresentationManifest < IiifPresentationManifest
       'label' => 'Current order'
     )
 
-    sequence['viewingDirection'] = VIEWING_DIRECTION[order] if order
+    sequence.viewingDirection = VIEWING_DIRECTION[order] if order
 
     manifest.thumbnail = [thumbnail_resource]
 

--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -91,7 +91,7 @@ class IiifPresentationManifest
       'label' => 'Current order'
     )
 
-    sequence['viewingDirection'] = VIEWING_DIRECTION[order] if order
+    sequence.viewingDirection = VIEWING_DIRECTION[order] if order
 
     manifest.thumbnail = thumbnail_resource
 


### PR DESCRIPTION
I stumbled on this while writing tests for osullivan that mimic our purl code as exactly as is practical.

Basically, the osullivan code uses underscores for the true keys of its hashes.  It is full of cleverness so that you can use different forms of accessors to get the data.  For example, both of these statements should pass:
```ruby
          expect(sequence_vd.viewing_direction).to eq 'left-to-right'
          expect(sequence_vd.viewingDirection).to eq 'left-to-right'
```
For this to be true, however, the underlying hash is expecting underscored keys.  So: 
```ruby
sequence_object['viewing_direction'] = 'left-to-right' # works for both
sequence_object['viewingDirection'] = 'left-to-right' # only works for .viewingDirection
sequence_object.viewingDirection = 'left-to-right' # works for both
sequence_object.viewing_direction = 'left-to-right' # works for both
```

Thus, @tingulfsen managed to pick the ONE WAY out of four that isn't appropriate for osullivan:  do NOT have camelcase keys as a direct hash method.

I also reopened #145  as I had an impression that Lynn wanted "left-to-right" to be explicitly added to the objects when there was no other clue about them.  That is not part of this PR ... but it is the same part of the code.