### PR TITLE
IIIF sequences should include the representative thumbnail image, eve…

### DIFF
--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -42,7 +42,8 @@ class IiifPresentationManifest
   # also is this right?  should it handle location rights too?
   def deliverable_file?(file)
     purl_resource.rights.stanford_only_rights_for_file(file.filename).first ||
-      purl_resource.rights.world_rights_for_file(file.filename).first
+      purl_resource.rights.world_rights_for_file(file.filename).first ||
+      thumbnail?(file)
   end
 
   def description_or_note
@@ -214,13 +215,17 @@ class IiifPresentationManifest
 
   # If not available, use the first image to create a thumbnail on the manifest
   def thumbnail_image
-    @thumbnail_image ||= page_images.detect(&:thumbnail?) || page_images.first
+    @thumbnail_image ||= page_images.detect { |file| thumbnail?(file) } || page_images.first
   end
 
   def thumbnail_base_uri
     @thumbnail_base_uri ||= begin
       stacks_iiif_base_url(thumbnail_image.druid, thumbnail_image.filename) if thumbnail_image
     end
+  end
+
+  def thumbnail?(file)
+    purl_resource.public_xml.thumb == "#{file.druid}/#{file.filename}"
   end
 
   def stacks_iiif_base_url(druid, filename)

--- a/app/models/public_xml.rb
+++ b/app/models/public_xml.rb
@@ -30,4 +30,8 @@ class PublicXml
 
     release == 'true'
   end
+
+  def thumb
+    document.root.at_xpath('thumb').try(:text)
+  end
 end

--- a/spec/features/iiif_manifest_spec.rb
+++ b/spec/features/iiif_manifest_spec.rb
@@ -63,6 +63,18 @@ describe 'IIIF v2 manifests' do
     expect(json['thumbnail']['@type']).to eq 'dctypes:Image'
   end
 
+  it 'includes the representative thumbnail as part of the image sequence' do
+    visit '/rf433wv2584/iiif/manifest.json'
+    json = JSON.parse(page.body)
+    expect(json['thumbnail']['@id']).to eq 'https://stacks.stanford.edu/image/iiif/rf433wv2584%2F9082000/full/!400,400/0/default.jpg'
+
+    expect(json['sequences'].length).to eq 1
+    canvas = json['sequences'].first['canvases'].first
+    expect(canvas['images'].length).to eq 1
+    image = canvas['images'].first
+    expect(image['resource']['@id']).to eq 'https://stacks.stanford.edu/image/iiif/rf433wv2584%2F9082000/full/full/0/default.jpg'
+  end
+
   it 'includes viewing direction when viewing direction is defined' do
     visit '/yr183sf1341/iiif3/manifest'
     json = JSON.parse(page.body)

--- a/spec/fixtures/document_cache/rf/433/wv/2584/public
+++ b/spec/fixtures/document_cache/rf/433/wv/2584/public
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:rf433wv2584" published="2017-08-29T18:57:44Z" publishVersion="dor-services/5.17.3">
+  <identityMetadata>
+    <sourceId source="Rumsey">9082</sourceId>
+    <objectId>druid:rf433wv2584</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>Midtown Manhattan, New York City.</objectLabel>
+    <objectType>item</objectType>
+    <otherId name="catkey">11524148</otherId>
+    <otherId name="uuid">d33b6c06-aaa0-11e6-9646-0050569b2d90</otherId>
+    <tag>Process : Content Type : Map</tag>
+    <tag>Project : Rumsey Map Collection : Batch 6 : Single Map</tag>
+    <tag>LAB : RUMSEY</tag>
+    <tag>Registered By : mtrott</tag>
+    <tag>Remediated By : 5.11.0</tag>
+  </identityMetadata>
+  <contentMetadata objectId="rf433wv2584" type="image">
+    <resource id="rf433wv2584_1" sequence="1" type="image">
+      <label>Image 1</label>
+      <file id="9082000.jp2" mimetype="image/jp2" size="107659456">
+        <imageData width="20190" height="28300"/>
+      </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <copyright>
+      <human type="copyright">Property rights reside with the repository, Copyright (c) Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license. </human>
+    </copyright>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <none/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">Image from the David Rumsey Map Collection courtesy Stanford University Libraries. To obtain permission to publish or reproduce commercially, please contact the David Rumsey Map Center at rumseymapcenter@stanford.edu.</human>
+      <machine type="creativeCommons">by-nc-sa</machine>
+      <human type="creativeCommons">Attribution Non-Commercial Share Alike 3.0 Unported</human>
+    </use>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:rf433wv2584">
+      <fedora:isMemberOf rdf:resource="info:fedora/druid:xh235dd9059"/>
+      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:xh235dd9059"/>
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Midtown Manhattan</dc:title>
+    <dc:contributor>Ishihara, Tadashi.</dc:contributor>
+    <dc:type>map</dc:type>
+    <dc:type>cartographic image</dc:type>
+    <dc:type>Maps.</dc:type>
+    <dc:type>Pictorial maps.</dc:type>
+    <dc:type>Aerial views.</dc:type>
+    <dc:date>2000</dc:date>
+    <dc:date>2000.</dc:date>
+    <dc:publisher>Tadashi Ishihara,</dc:publisher>
+    <dc:language>eng</dc:language>
+    <dc:format>1 map ; 1 maps ; 113 x 77 cm.</dc:format>
+    <dc:format>unmediated</dc:format>
+    <dc:description>Full color. Bird's eye view.</dc:description>
+    <dc:description>Separate Map.</dc:description>
+    <dc:description type="local" displayLabel="Local note">Pub list no.: 9082.000.</dc:description>
+    <dc:subject>Pictorial maps</dc:subject>
+    <dc:coverage>New York (State)</dc:coverage>
+    <dc:coverage>New York</dc:coverage>
+    <dc:coverage>Manhattan</dc:coverage>
+    <dc:coverage>21st century</dc:coverage>
+    <dc:subject>Pictorial maps--New York (State)--New York--Manhattan--21st century</dc:subject>
+    <dc:subject>Bird's-eye views</dc:subject>
+    <dc:coverage>New York (State)</dc:coverage>
+    <dc:coverage>New York</dc:coverage>
+    <dc:coverage>Manhattan</dc:coverage>
+    <dc:coverage>21st century</dc:coverage>
+    <dc:subject>Bird's-eye views--New York (State)--New York--Manhattan--21st century</dc:subject>
+    <dc:coverage>New York (State)</dc:coverage>
+    <dc:coverage>21th century</dc:coverage>
+    <dc:coverage>New York (N.Y.)</dc:coverage>
+    <dc:coverage>21th century</dc:coverage>
+    <dc:coverage>Manhattan (New York, N.Y.)</dc:coverage>
+    <dc:coverage>21th century</dc:coverage>
+    <dc:coverage>Midtown Manhattan (New York, N.Y.)</dc:coverage>
+    <dc:coverage>21th century</dc:coverage>
+    <dc:subject>G3804.N4:2M513 A3 2000 .I8</dc:subject>
+    <dc:identifier>http://www.davidrumsey.com/luna/servlet/view/search?q=pub_list_no=%229082.000%22%20LIMIT:RUMSEY~8~1&amp;sort=Pub_List_No_InitialSort,Pub_Date,Pub_List_No,Series_No</dc:identifier>
+    <dc:relation type="collection">David Rumsey Map Collection at Stanford University Libraries</dc:relation>
+  </oai_dc:dc>
+  <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+    <titleInfo>
+      <title>Midtown Manhattan</title>
+    </titleInfo>
+    <name type="personal" usage="primary">
+      <namePart>Ishihara, Tadashi.</namePart>
+    </name>
+    <typeOfResource>cartographic</typeOfResource>
+    <genre authority="marcgt">map</genre>
+    <genre authority="rdacontent">cartographic image</genre>
+    <genre authority="lcgft">Maps.</genre>
+    <genre authority="lcgft">Pictorial maps.</genre>
+    <genre authority="lcgft">Aerial views.</genre>
+    <originInfo>
+      <place>
+        <placeTerm type="code" authority="marccountry">ja</placeTerm>
+      </place>
+      <dateIssued encoding="marc">2000</dateIssued>
+      <issuance>monographic</issuance>
+    </originInfo>
+    <originInfo displayLabel="publisher">
+      <place>
+        <placeTerm>Osaka-City :</placeTerm>
+      </place>
+      <publisher>Tadashi Ishihara,</publisher>
+      <dateIssued>2000.</dateIssued>
+    </originInfo>
+    <language>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+    </language>
+    <physicalDescription>
+      <extent>1 map ; 1 maps ; 113 x 77 cm.</extent>
+      <form type="media" authority="rdamedia">unmediated</form>
+      <form type="carrier" authority="rdacarrier">sheet</form>
+    </physicalDescription>
+    <note type="statement of responsibility" altRepGroup="00"/>
+    <note>Full color. Bird's eye view.</note>
+    <note>Separate Map.</note>
+    <note type="local" displayLabel="Local note">Pub list no.: 9082.000.</note>
+    <subject authority="lcsh">
+      <topic>Pictorial maps</topic>
+      <geographic>New York (State)</geographic>
+      <geographic>New York</geographic>
+      <geographic>Manhattan</geographic>
+      <temporal>21st century</temporal>
+    </subject>
+    <subject authority="tgm">
+      <topic>Bird's-eye views</topic>
+      <geographic>New York (State)</geographic>
+      <geographic>New York</geographic>
+      <geographic>Manhattan</geographic>
+      <temporal>21st century</temporal>
+    </subject>
+    <subject authority="lcsh">
+      <geographic>New York (State)</geographic>
+      <genre>Maps</genre>
+      <temporal>21th century</temporal>
+    </subject>
+    <subject authority="lcsh">
+      <geographic>New York (N.Y.)</geographic>
+      <genre>Maps</genre>
+      <temporal>21th century</temporal>
+    </subject>
+    <subject authority="lcsh">
+      <geographic>Manhattan (New York, N.Y.)</geographic>
+      <genre>Maps</genre>
+      <temporal>21th century</temporal>
+    </subject>
+    <subject authority="lcsh">
+      <geographic>Midtown Manhattan (New York, N.Y.)</geographic>
+      <genre>Maps</genre>
+      <temporal>21th century</temporal>
+    </subject>
+    <classification authority="lcc">G3804.N4:2M513 A3 2000 .I8</classification>
+    <location>
+      <url displayLabel="electronic resource" usage="primary display">http://www.davidrumsey.com/luna/servlet/view/search?q=pub_list_no=%229082.000%22%20LIMIT:RUMSEY~8~1&amp;sort=Pub_List_No_InitialSort,Pub_Date,Pub_List_No,Series_No</url>
+    </location>
+    <recordInfo>
+      <recordContentSource authority="marcorg">CSt</recordContentSource>
+      <recordCreationDate encoding="marc">151215</recordCreationDate>
+      <recordIdentifier>a11524148</recordIdentifier>
+      <recordOrigin>Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)</recordOrigin>
+      <languageOfCataloging>
+        <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+      </languageOfCataloging>
+    </recordInfo>
+    <relatedItem type="host">
+      <titleInfo>
+        <title>David Rumsey Map Collection at Stanford University Libraries</title>
+      </titleInfo>
+      <location>
+        <url>https://purl.stanford.edu/xh235dd9059</url>
+      </location>
+      <typeOfResource collection="yes"/>
+    </relatedItem>
+    <accessCondition type="useAndReproduction">Image from the David Rumsey Map Collection courtesy Stanford University Libraries. To obtain permission to publish or reproduce commercially, please contact the David Rumsey Map Center at rumseymapcenter@stanford.edu.</accessCondition>
+    <accessCondition type="copyright">Property rights reside with the repository, Copyright (c) Stanford University.  Images may be reproduced or transmitted, but not for commercial use. For commercial use or commercial republication, contact rumseymapcenter@stanford.edu This work is licensed under a Creative Commons License. By downloading any images from this site, you agree to the terms of that license.</accessCondition>
+    <accessCondition type="license">CC by-nc-sa: Attribution Non-Commercial Share Alike 3.0 Unported</accessCondition>
+  </mods>
+  <releaseData>
+    <release to="Searchworks">true</release>
+  </releaseData>
+  <thumb>rf433wv2584/9082000.jp2</thumb>
+</publicObject>


### PR DESCRIPTION
…n if it is not otherwise available

Closes #181 