### PR TITLE
add "Available Online" link back to purl html

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -29,6 +29,10 @@ class Iiif3PresentationManifest < IiifPresentationManifest
     manifest.viewingHint = 'paged' if type == 'book'
 
     manifest.metadata = dc_to_iiif_metadata if dc_to_iiif_metadata.present?
+    manifest.metadata.unshift(
+      'label' => 'Available Online',
+      'value' => "<a href='#{controller.purl_url(druid)}'>#{controller.purl_url(druid)}</a>"
+    )
 
     manifest.description = description_or_note
     order = reading_order

--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -83,6 +83,10 @@ class IiifPresentationManifest
     manifest.viewingHint = 'paged' if type == 'book'
 
     manifest.metadata = dc_to_iiif_metadata if dc_to_iiif_metadata.present?
+    manifest.metadata.unshift(
+      'label' => 'Available Online',
+      'value' => "<a href='#{controller.purl_url(druid)}'>#{controller.purl_url(druid)}</a>"
+    )
 
     manifest.description = description_or_note
     order = reading_order

--- a/spec/features/iiif3_manifest_spec.rb
+++ b/spec/features/iiif3_manifest_spec.rb
@@ -28,9 +28,10 @@ describe 'IIIF v3 manifests' do
     expect(image['body']['id']).to eq 'https://stacks.stanford.edu/image/iiif/bb157hs6068%2Fbb157hs6068_05_0001/full/full/0/default.jpg'
 
     expect(json['metadata'].class).to eq Array
-    expect(json['metadata'].size).to eq(21) # 20 DC elements are there plus the publish date
+    expect(json['metadata'].size).to eq(22) # 20 DC elements are there + the publish date + Available Online
     # rubocop:disable Metrics/LineLength
     expected_dc_metadata = [
+      { 'label' => 'Available Online', 'value' => "<a href='http://www.example.com/bb157hs6068'>http://www.example.com/bb157hs6068</a>" },
       { 'label' => 'Type', 'value' => 'map' },
       { 'label' => 'Type', 'value' => 'Digital Maps' },
       { 'label' => 'Rights', 'value' => "Stanford University Libraries and Academic Information Resources - Terms of Use SULAIR Web sites are subject to Stanford University's standard Terms of Use (See http://www.stanford.edu/home/atoz/terms.html) These terms include a limited personal, non-exclusive, non-transferable license to access and use the sites, and to download - where permitted - material for personal, non-commercial, non-display use only. Please contact the University Librarian to request permission to use SULAIR Web sites and contents beyond the scope of the above license, including but not limited to republication to a group or republishing the Web site or parts of the Web site. SULAIR provides access to a variety of external databases and resources, which sites are governed by their own Terms of Use, as well as contractual access restrictions. The Terms of Use on these external sites always govern the data available there. Please consult with library staff if you have questions about data access and availability." },
@@ -112,7 +113,7 @@ describe 'IIIF v3 manifests' do
     json = JSON.parse(page.body)
 
     expect(json['sequences'].length).to eq 1
-    expect(json['metadata'].length).to eq 28
+    expect(json['metadata'].length).to eq 29
   end
 
   # Virtual objects consist of a parent object and children objects who hold the file resources

--- a/spec/features/iiif_manifest_spec.rb
+++ b/spec/features/iiif_manifest_spec.rb
@@ -26,9 +26,10 @@ describe 'IIIF v2 manifests' do
     expect(image['resource']['@id']).to eq 'https://stacks.stanford.edu/image/iiif/bb157hs6068%2Fbb157hs6068_05_0001/full/full/0/default.jpg'
 
     expect(json['metadata'].class).to eq Array
-    expect(json['metadata'].size).to eq(21) # 20 DC elements are there plus the publish date
+    expect(json['metadata'].size).to eq(22) # 20 DC elements are there + the publish date + Available Online
     # rubocop:disable Metrics/LineLength
-    expected_dc_metadata = [
+    expected_metadata = [
+      { 'label' => 'Available Online', 'value' => "<a href='http://www.example.com/bb157hs6068'>http://www.example.com/bb157hs6068</a>" },
       { 'label' => 'Type', 'value' => 'map' },
       { 'label' => 'Type', 'value' => 'Digital Maps' },
       { 'label' => 'Rights', 'value' => "Stanford University Libraries and Academic Information Resources - Terms of Use SULAIR Web sites are subject to Stanford University's standard Terms of Use (See http://www.stanford.edu/home/atoz/terms.html) These terms include a limited personal, non-exclusive, non-transferable license to access and use the sites, and to download - where permitted - material for personal, non-commercial, non-display use only. Please contact the University Librarian to request permission to use SULAIR Web sites and contents beyond the scope of the above license, including but not limited to republication to a group or republishing the Web site or parts of the Web site. SULAIR provides access to a variety of external databases and resources, which sites are governed by their own Terms of Use, as well as contractual access restrictions. The Terms of Use on these external sites always govern the data available there. Please consult with library staff if you have questions about data access and availability." },
@@ -52,7 +53,7 @@ describe 'IIIF v2 manifests' do
       { 'label' => 'PublishDate', 'value' => '2016-06-16T21:46:16Z' } # publish date was added
     ]
     # rubocop:enable Metrics/LineLength
-    expect(json['metadata']).to eq(expected_dc_metadata)
+    expect(json['metadata']).to eq(expected_metadata)
   end
 
   it 'includes a representative thumbnail' do
@@ -128,7 +129,7 @@ describe 'IIIF v2 manifests' do
     json = JSON.parse(page.body)
 
     expect(json['sequences'].length).to eq 1
-    expect(json['metadata'].length).to eq 28
+    expect(json['metadata'].length).to eq 29
   end
 
   # Virtual objects consist of a parent object and children objects who hold the file resources

--- a/spec/integration/purl_spec.rb
+++ b/spec/integration/purl_spec.rb
@@ -35,7 +35,7 @@ describe 'purl', type: :feature do
         visit "/#{@manifest_object}/iiif/manifest"
         json_body = JSON.parse(page.body)
         expect(json_body['label']).to eq('John Wyclif and his followers, Tracts in Middle English')
-        expect(json_body['metadata'].length).to eq 16
+        expect(json_body['metadata'].length).to eq 17
       end
       it 'renders nil for a non-manifest' do
         visit "/#{@file_object}/iiif/manifest"

--- a/spec/integration/purl_spec.rb
+++ b/spec/integration/purl_spec.rb
@@ -47,7 +47,7 @@ describe 'purl', type: :feature do
         visit "/#{@manifest_object}/iiif3/manifest"
         json_body = JSON.parse(page.body)
         expect(json_body['label']).to eq('John Wyclif and his followers, Tracts in Middle English')
-        expect(json_body['metadata'].length).to eq 16
+        expect(json_body['metadata'].length).to eq 17
       end
     end
   end


### PR DESCRIPTION
This enables UV to show in the right metadata panel

