### PR TITLE
`scss-lint` has been renamed to `scss_lint` to follow proper RubyGems…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,8 +88,8 @@ group :development, :test do
   # Rubocop is a static code analyzer to enforce style.
   gem 'rubocop', '= 0.46.0', require: false
 
-  # scss-lint will test the scss files to enfoce styles
-  gem 'scss-lint', require: false
+  # scss_lint will test the scss files to enfoce styles
+  gem 'scss_lint', require: false
 
   # Coveralls for code coverage metrics
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,9 +263,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scss-lint (0.38.0)
-      rainbow (~> 2.0)
-      sass (~> 3.4.1)
+    scss_lint (0.54.0)
+      rake (>= 0.9, < 13)
+      sass (~> 3.4.20)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -363,7 +363,7 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   rubocop (= 0.46.0)
   sass-rails (~> 5.0)
-  scss-lint
+  scss_lint
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
… naming conventions