### PR TITLE
adds support for requesting v3 manifests using content negotiation 

### DIFF
--- a/app/models/accept_header_constraint.rb
+++ b/app/models/accept_header_constraint.rb
@@ -1,0 +1,9 @@
+class AcceptHeaderConstraint
+  PRESENTATION_V3_ACCEPT_HEADER = %r{application\/ld\+json;profile=\"http:\/\/iiif.io\/api\/presentation\/3\/context\.json\"}.freeze
+
+  def initialize; end
+
+  def matches?(request)
+    PRESENTATION_V3_ACCEPT_HEADER.match?(request.headers['Accept'])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
+##
+# Routing for PURL
+# 
+# IIIF Routing
+# v3 if a client specifically requests v3 via URL or Accept headers
+# v2 by default
 Rails.application.routes.draw do
   root to: 'purl#index'
 
@@ -12,6 +18,9 @@ Rails.application.routes.draw do
   get ':id' => 'purl#show', as: :purl
   get ':id/embed', to: redirect("/iframe/?url=#{Settings.embed.url % { druid: '%{id}' }}")
 
+  ##
+  # These routes should only be used until our viewers support v3 manifests.
+  # We should aim to only serve a IIIF resource from a single URL.
   get '/:id/iiif3/manifest' => 'iiif_v3#manifest', as: :iiif3_manifest, format: false
   get '/:id/iiif3/manifest.json', to: redirect('/%{id}/iiif3/manifest')
 
@@ -24,6 +33,25 @@ Rails.application.routes.draw do
   get '/:id/iiif3/annotation/:annotation_id' => 'iiif_v3#annotation', as: :iiif3_annotation, format: false
   get '/:id/iiif3/annotation/:annotation_id.json', to: redirect('/%{id}/iiif3/annotation/%{annotation_id}')
 
+  ##
+  # Sets up the ability to specify an Accept header which should provide a v3
+  # manifest. Eventually, v3 should be served by default.
+  scope format: true, constraints: AcceptHeaderConstraint.new do
+    get '/:id/iiif/manifest' => 'iiif_v3#manifest', format: false
+    get '/:id/iiif/manifest.json', to: redirect('/%{id}/iiif3/manifest')
+
+    get '/:id/iiif/canvas/:resource_id' => 'iiif_v3#canvas', format: false
+    get '/:id/iiif/canvas/:resource_id.json', to: redirect('/%{id}/iiif3/canvas/%{resource_id}')
+
+    get '/:id/iiif/annotation_page/:annotation_page_id' => 'iiif_v3#annotation_page', format: false
+    get '/:id/iiif/annotation_page/:annotation_page_id.json', to: redirect('/%{id}/iiif3/annotation_page/%{annotation_page_id}')
+
+    get '/:id/iiif/annotation/:annotation_id' => 'iiif_v3#annotation', format: false
+    get '/:id/iiif/annotation/:annotation_id.json', to: redirect('/%{id}/iiif3/annotation/%{annotation_id}')
+  end
+
+  ##
+  # Default to IIIF Presentatation API v2 until our clients support v3.
   get '/:id/iiif/manifest' => 'iiif_v2#manifest', as: :iiif_manifest, format: false
   get '/:id/iiif/manifest.json', to: redirect('/%{id}/iiif/manifest')
 

--- a/spec/model/accept_header_constraint_spec.rb
+++ b/spec/model/accept_header_constraint_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe AcceptHeaderConstraint do
+  subject(:instance) { described_class.new }
+  let(:v3_request) do
+    double(
+      'request',
+      headers: { 'Accept' => 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"' }
+    )
+  end
+  let(:default_request) do
+    double('request', headers: {})
+  end
+  describe '#matches?' do
+    context 'with proper Accept headers' do
+      it { expect(instance.matches?(v3_request)).to be_truthy }
+    end
+    context 'without proper Accept headers' do
+      it { expect(instance.matches?(default_request)).to be_falsy }
+    end
+  end
+end

--- a/spec/request/purl_spec.rb
+++ b/spec/request/purl_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe 'PURL API', type: :request do
   end
 
   context 'IIIF v3 requests' do
+    it 'using accept header provides v3 manifest' do
+      get(
+        '/bb157hs6068/iiif/manifest',
+        params: {},
+        headers: { 'Accept' => 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"' }
+      )
+      expect(response.body).to include 'http://iiif.io/api/presentation/3/context.json'
+    end
+
     it 'redirects manifest.json requests' do
       get '/1/iiif3/manifest.json'
       expect(response).to redirect_to('/1/iiif3/manifest')


### PR DESCRIPTION
Fixes #233

I'm definitely open to other approaches here for supporting this.

You can check this locally:

```sh
$ curl -v -H "Accept: application/ld+json;profile=\"http://iiif.io/api/presentation/3/context.json\"" http://127.0.0.1:3000/sn904cj3429/iiif/manifest
```