### PR TITLE
Update SU footer

### DIFF
--- a/app/assets/stylesheets/modules/sul-footer.scss
+++ b/app/assets/stylesheets/modules/sul-footer.scss
@@ -65,6 +65,11 @@ $sul-footer-height: 80px;
     }
   }
   #sul-footer-img {
+    a,
+    a:hover,
+    a:focus { 
+      border-bottom: 0;
+    }
     display: table-cell;
     vertical-align: middle;
     width: 162px;

--- a/app/assets/stylesheets/modules/sul-footer.scss
+++ b/app/assets/stylesheets/modules/sul-footer.scss
@@ -1,26 +1,43 @@
+$stanford-footer-height: 250px;
+$stanford-footer-md-height: 140px;
+$sul-footer-height: 80px;
+
 #su-content {
-	padding-bottom: 200px !important;
+  padding-bottom: $stanford-footer-height + $sul-footer-height !important;
+
+  @media (min-width: 768px) {
+    padding-bottom: $stanford-footer-md-height + $sul-footer-height !important;
+  }
 }
+
 #sul-footer-container {
-	padding: 0 !important;
-	position: relative;
-	margin-top: -200px;
-	min-height: 200px;
-	clear: both;
-	-webkit-box-shadow: 0 4px 8px -8px rgba(0,0,0,0.2) inset;
-	box-shadow: 0 4px 8px -8px rgba(0,0,0,0.2) inset;
-	background-color: $sul-footer-bg-color;
-	}
-#sul-footer {
-	display: table;
-	height: 80px;
-	padding: 0px;
+  background-color: $sul-footer-bg-color;
+  box-shadow: inset 0 4px 8px -8px $sul-shadow-color;
+  clear: both;
+  margin-top: -1 * ($stanford-footer-height + $sul-footer-height);
+  min-height: $stanford-footer-height + $sul-footer-height;
+
+  @media (min-width: 768px) {
+    margin-top: -1 * ($stanford-footer-md-height + $sul-footer-height);
+    min-height: $stanford-footer-md-height + $sul-footer-height;
+  }
+
+  padding: 0;
+  position: relative;
 }
+
+#sul-footer {
+  display: table;
+  height: $sul-footer-height;
+  padding: 0;
+}
+
 #sul-footer-img {
 	display: table-cell;
 	vertical-align: middle;
 	width: 162px;
 }
+
 #sul-footer-links {
 	display: table-cell;
 	vertical-align: middle;
@@ -28,20 +45,44 @@
 	padding-left: 15px;
 	font-size: small;
 }
-#sul-footer li a {
-	white-space: nowrap;
-}
-#sul-footer ul {
-	margin: 0;
-	padding: 0;
-	list-style-type: none;
-}
-#sul-footer ul li {
-	margin:  0 13px 3px 0;
-	padding: 0;
-	display: inline;
+
+#sul-footer {
+  display: table;
+  height: $sul-footer-height;
+  padding: 0;
+
+  ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    li {
+      display: inline;
+      margin: 0 13px 3px 0;
+      padding: 0;
+      a {
+        white-space: nowrap;
+      }
+    }
+  }
+  #sul-footer-img {
+    display: table-cell;
+    vertical-align: middle;
+    width: 162px;
+  }
+  #sul-footer-links {
+    display: table-cell;
+    font-size: small;
+    padding-left: 15px;
+    text-align: left;
+    vertical-align: middle;
+  }
 }
 
 #global-footer {max-width: 100%;}
 #global-footer p {max-width: 100%;}
 #global-footer #bottom-text {margin-right: 6px;}
+#global-footer {
+  .vcard {
+    margin-left: 2rem;
+  }
+}

--- a/app/assets/stylesheets/sul-variables.scss
+++ b/app/assets/stylesheets/sul-variables.scss
@@ -43,6 +43,7 @@ $btn-sul-toolbar-bar-hover-bg: $color-beige-30;
 $sul-btn-disabled-color: $color-gray;
 $sul-btn-disabled-opacity: 0.75;
 $sul-tooltip-bg: $cadet-blue;
+$sul-shadow-color: rgba(0, 0, 0, .2);
 
 // Sizes
 $gallery-document-width: 176px;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,13 +29,6 @@
     <%= twitter_card %>
     <%= content_for(:head) %>
 
-    <!--[if IE 8]>
-      <link rel="stylesheet" type="text/css" href="https://www.stanford.edu/su-identity/css/ie/ie8.css" />
-    <![endif]-->
-    <!--[if IE 7]>
-      <link rel="stylesheet" type="text/css" href="https://www.stanford.edu/su-identity/css/ie/ie7.css" />
-    <![endif]-->
-
   </head>
   <body>
     <%= render 'shared/skip_to_nav' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <%= favicon_link_tag 'favicon.ico' %>
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= stylesheet_link_tag 'print', media: 'print' %>
-    <link href="https://www.stanford.edu/su-identity/css/su-identity.css" rel="stylesheet">
+    <link href="https://www-media.stanford.edu/su-identity/css/su-identity.css" rel="stylesheet">
     <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>

--- a/app/views/shared/_su_footer.html.erb
+++ b/app/views/shared/_su_footer.html.erb
@@ -1,45 +1,52 @@
 <footer role="contentinfo">
   <div id="sul-footer-container">
-    <div id="sul-footer">
+    <div id="sul-footer" class="container">
       <div id="sul-footer-img" class="span2">
-        <%= image_tag "sul-logo-stacked.svg", alt: "", height: 45 %>
+        <%= link_to 'https://library.stanford.edu' do %>
+          <%= image_tag "sul-logo-stacked.svg", alt: "Stanford Libraries", height: 45 %>
+        <% end %>
       </div>
       <div id="sul-footer-links" class="span2">
         <ul>
-          <li><a href="http://library.stanford.edu">Stanford University Libraries</a></li>
-          <li><a href="http://library.stanford.edu/hours">Hours &amp; locations</a></li>
-          <li> <a href="http://library.stanford.edu/myawrap.html">My Account</a></li>
-          <li> <a href="http://library.stanford.edu/ask">Ask us</a></li>
-          <li> <a href="http://library.stanford.edu/opt-out">Opt out of analytics</a></li>
+          <li><a href="https://library.stanford.edu/hours">Hours &amp; locations</a></li>
+          <li><a href="https://library.stanford.edu/myaccount">My Account</a></li>
+          <li><a href="https://library.stanford.edu/ask">Ask us</a></li>
+          <li><a href="https://library.stanford.edu/opt-out">Opt out of analytics</a></li>
+          <li><a href="https://library-status.stanford.edu/">System status</a></li>
         </ul>
       </div>
     </div>
   </div>
 </footer>
 <!-- Global footer snippet start -->
-<div id="global-footer">
+<div id="global-footer" role="contentinfo">
   <div class="container">
     <div class="row">
-      <div id="bottom-logo" class="span2">
-        <a href="http://www.stanford.edu">
-          <img src="https://www.stanford.edu/su-identity/images/footer-stanford-logo@2x.png" alt="Stanford University" width="105" height="49"/>
+      <div id="bottom-logo" class="col-sm-2">
+        <a href="https://www.stanford.edu">
+          <img src="https://www-media.stanford.edu/su-identity/images/footer-stanford-logo@2x.png" alt="Stanford University" width="105" height="49"/>
         </a>
       </div>
       <!-- #bottom-logo end -->
-      <div id="bottom-text" class="span10">
+      <div id="bottom-text" class="col-sm-8">
         <ul>
-          <li class="home"><a href="http://www.stanford.edu">SU Home</a></li>
-          <li class="maps alt"><a href="http://visit.stanford.edu/plan/maps.html">Maps &amp; Directions</a></li>
-          <li class="search-stanford"><a href="http://www.stanford.edu/search/">Search Stanford</a></li>
-          <li class="terms alt"><a href="http://www.stanford.edu/site/terms.html">Terms of Use</a></li>
-          <li class="emergency-info"><a href="http://emergency.stanford.edu">Emergency Info</a></li>
+          <li class="home"><a href="https://www.stanford.edu">Stanford Home</a></li>
+          <li class="maps alt"><a href="https://visit.stanford.edu/plan/">Maps & Directions</a></li>
+          <li class="search-stanford"><a href="https://www.stanford.edu/search/">Search Stanford</a></li>
+          <li class="emergency alt"><a href="https://emergency.stanford.edu">Emergency Info</a></li>
+        </ul>
+        <ul id="policy-links">
+          <li><a href="https://www.stanford.edu/site/terms/" title="Terms of use for sites">Terms of Use</a></li>
+          <li><a href="https://www.stanford.edu/site/privacy/" title="Privacy and cookie policy">Privacy</a></li>
+          <li><a href="https://uit.stanford.edu/security/copyright-infringement" title="Report alleged copyright infringement">Copyright</a></li>
+          <li><a href="https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4" title="Ownership and use of Stanford trademarks and images">Trademarks</a></li>
+          <li><a href="http://exploredegrees.stanford.edu/nonacademicregulations/nondiscrimination/" title="Non-discrimination policy">Non-Discrimination</a></li>
+          <li><a href="https://www.stanford.edu/site/accessibility" title="Report web accessibility issues">Accessibility</a></li>
         </ul>
       </div> <!-- .bottom-text end -->
       <div class="clear"></div>
-      <p class="copyright vcard">&copy; <span class="fn org">Stanford University</span>, <span class="adr"> <span class="locality">Stanford</span>, <span class="region">California</span> <span class="postal-code">94305</span></span>.&nbsp;&nbsp;
-      <span id="copyright-complaint"><a href="http://www.stanford.edu/group/security/dmca.html" class="copyright-complaint" >Copyright Complaints</a></span>
+      <p class="copyright vcard offset-sm-2">&copy; <span class="fn org">Stanford University</span>, <span class="adr"> <span class="locality">Stanford</span>, <span class="region">California</span> <span class="postal-code">94305</span></span>.
       </p>
     </div> <!-- .row end -->
   </div> <!-- .container end -->
 </div> <!-- global-footer end -->
-<!-- Global footer snippet end -->


### PR DESCRIPTION
One q to ask. Purl uses footer styling (look at the links) from sul-styles. Should we keep doing this?

<img width="1232" alt="Screen Shot 2019-08-05 at 5 22 34 PM" src="https://user-images.githubusercontent.com/1656824/62500904-b2471300-b7a5-11e9-9c29-36c23c5c352d.png">
