### PR TITLE
Display nested related items on the purl page; fixes #223

### DIFF
--- a/app/views/purl/_mods_bibliographic.html.erb
+++ b/app/views/purl/_mods_bibliographic.html.erb
@@ -11,6 +11,10 @@
   <%= mods_record_field(related_item) %>
 <% end %>
 
+<% document.mods.nestedRelatedItem.each do |related_item| %>
+  <%= mods_record_field(related_item) %>
+<% end %>
+
 <% document.mods.identifier.each do |identifier| %>
   <%= mods_record_field(identifier) %>
 <% end %>

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -18,6 +18,7 @@ describe 'Integration Scenarios' do
       expect(page).to have_content 'Creator Paget, Francis Edward, 1806-1882'
       expect(page).to have_metadata_section 'Bibliographic information'
       expect(page).to have_metadata_section 'Also listed in'
+      expect(page).to have_content 'Vicar of Roost'
     end
 
     it 'has a link to the searchworks record' do


### PR DESCRIPTION
Related hosts and constituent items were broken out of related item in https://github.com/sul-dlss/mods_display/pull/45. This commit once again displays them (as we're doing in exhibits, presumably?) on the purl page.

<img width="550" alt="Screen Shot 2019-09-10 at 08 16 16" src="https://user-images.githubusercontent.com/111218/64626800-4dce3380-d3a3-11e9-968a-e60ed9a43e4e.png">