### PR TITLE
Remove linked database.yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,9 +79,6 @@ group :development, :test do
   gem 'selenium-webdriver', '!= 3.13.0'
   gem 'webdrivers'
 
-  # Database cleaner allows us to clean the entire database after certain tests
-  gem 'database_cleaner'
-
   # Rubocop is a static code analyzer to enforce style.
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,6 @@ GEM
       dry-validation (~> 1.0, >= 1.0.0)
     crass (1.0.6)
     dalli (2.7.10)
-    database_cleaner (1.8.4)
     deep_merge (1.2.1)
     diff-lcs (1.3)
     dlss-capistrano (3.5.0)
@@ -385,7 +384,6 @@ DEPENDENCIES
   capybara
   config
   dalli
-  database_cleaner
   dlss-capistrano
   dor-rights-auth
   faraday
@@ -423,4 +421,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -20,7 +20,7 @@ set :log_level, :info
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w(config/secrets.yml config/database.yml config/honeybadger.yml config/newrelic.yml public/robots.txt)
+set :linked_files, %w(config/secrets.yml config/honeybadger.yml config/newrelic.yml public/robots.txt)
 
 # Default value for linked_dirs is []
 set :linked_dirs, %w(config/settings log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)


### PR DESCRIPTION
Looks like this file was still hanging out on the old servers. I've left in sqlite as to not try and pry out ActiveRecord to make upgrading easier.