### PR TITLE
Check that a filed offered for download is actually downloadable

### DIFF
--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -41,7 +41,7 @@ class IiifPresentationManifest
 
   def object_files
     @object_files ||= resources.select do |file|
-      object?(file) && deliverable_file?(file)
+      object?(file) && downloadable_file?(file)
     end
   end
 

--- a/spec/features/iiif_manifest_spec.rb
+++ b/spec/features/iiif_manifest_spec.rb
@@ -193,6 +193,13 @@ describe 'IIIF v2 manifests' do
     )
   end
 
+  it 'does not advertise downloadable files for stanford-only no-download content' do
+    visit '/bf995rh7184/iiif/manifest'
+    json = JSON.parse(page.body)
+
+    expect(json['sequences'].first).not_to include 'rendering'
+  end
+
   # Virtual objects consist of a parent object and children objects who hold the file resources
   context 'virtual objects' do
     describe 'first child object' do


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/sul-embed/issues/481 (assuming mirador pulls from the iiif manifest?)

