### PR TITLE
Give the upper metadata dt an auto flex-basis so it takes up the …

### DIFF
--- a/app/assets/stylesheets/modules/record-metadata-section.scss
+++ b/app/assets/stylesheets/modules/record-metadata-section.scss
@@ -26,6 +26,7 @@
   }
   dt {
     @extend .col;
+    flex-basis: auto;
   }
   dd {
     @extend .w-75;


### PR DESCRIPTION
…whole line.

Fixes #407

 ## Before (nw037gk9818)
<img width="960" alt="nw037gk9818-before" src="https://user-images.githubusercontent.com/96776/83715980-7eb26080-a5e3-11ea-9993-8798af428373.png">

## After (nw037gk9818)
<img width="710" alt="nw037gk9818-after" src="https://user-images.githubusercontent.com/96776/83715982-7fe38d80-a5e3-11ea-97db-44aca0f746ff.png">
