### PR TITLE
Add a redirect to retrieve files from stacks

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -39,6 +39,10 @@ class PurlController < ApplicationController
   end
   # rubocop:enable Metrics/AbcSize
 
+  def file
+    redirect_to Settings.stacks.url + '/file/druid:' + ERB::Util.url_encode(params[:id]) + '/' + ERB::Util.url_encode(params[:file])
+  end
+
   private
 
   # validate that the id is of the proper format

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 ##
 # Routing for PURL
-# 
+#
 # IIIF Routing
 # v3 if a client specifically requests v3 via URL or Accept headers
 # v2 by default
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
 
   get ':id' => 'purl#show', as: :purl
   get ':id/embed', to: redirect("/iframe/?url=#{Settings.embed.url % { druid: '%{id}' }}")
+  get ':id/file/:file' => 'purl#file', as: :purl_file
 
   ##
   # These routes should only be used until our viewers support v3 manifests.

--- a/spec/controller/purl_controller_spec.rb
+++ b/spec/controller/purl_controller_spec.rb
@@ -4,4 +4,9 @@ describe PurlController, type: :controller do
   it 'should render for a published item' do
     get :show, params: { id: '/bb157hs6068' }
   end
+
+  it 'redirects to stacks urls' do
+    response = get :file, params: { id: 'bb157hs6068', file: 'xyz' }
+    expect(response).to redirect_to 'https://stacks.stanford.edu/file/druid:bb157hs6068/xyz'
+  end
 end


### PR DESCRIPTION
I believe I've heard an architectural assertion that PURL shouldn't know about files because they're more ephemeral than the PURL page itself, so I don't think we should use or expose this route except as a handy shortcut for people who know about it.  