### PR TITLE
Respond to OPTIONS requests with CORS headers that support content negotiation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, except: [:options]
 
   helper_method :current_user
 
@@ -9,6 +9,15 @@ class ApplicationController < ActionController::Base
 
   def current_user?
     current_user.present?
+  end
+
+  def options
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
+    response.headers['Access-Control-Allow-Headers'] = 'Accept'
+    response.headers['Access-Control-Max-Age'] = 1.day.to_i
+
+    head :ok
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   post '/preview' => 'preview#show'
 
   get ':id' => 'purl#show', as: :purl
+  options ':id', to: 'purl#options'
   get ':id/embed', to: redirect("/iframe/?url=#{Settings.embed.url % { druid: '%{id}' }}")
   get ':id/file/:file' => 'purl#file', as: :purl_file
 
@@ -51,6 +52,7 @@ Rails.application.routes.draw do
 
     get '/:id/iiif/annotation/:annotation_id' => 'iiif_v3#annotation', format: false
     get '/:id/iiif/annotation/:annotation_id.json', to: redirect('/%{id}/iiif3/annotation/%{annotation_id}')
+    options '/:id/*whatever', to: 'iiif_v3#options'
   end
 
   ##
@@ -68,4 +70,5 @@ Rails.application.routes.draw do
   # Deferenceable annotationLists for additional annotationList "other content"
   get '/:id/iiif/annotationList/:resource_id' => 'iiif_v2#annotation_list', as: :iiif_annotation_list, format: false
   get '/:id/iiif/annotationList/:resource_id.json', to: redirect('/%{id}/iiif/annotationList/%{resource_id}')
+  options '/:id/*whatever', to: 'iiif_v2#options'
 end

--- a/spec/request/purl_spec.rb
+++ b/spec/request/purl_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'PURL API', type: :request do
+  context 'PURL page' do
+    it 'responds to OPTIONS requests' do
+      options '/bb157hs6068'
+      expect(response).to be_successful
+      expect(response.headers['Access-Control-Allow-Headers']).to include 'Accept'
+    end
+  end
+
   context 'IIIF v2 requests' do
     it 'redirects manifest.json requests' do
       get '/1/iiif/manifest.json'
@@ -16,6 +24,12 @@ RSpec.describe 'PURL API', type: :request do
       get '/1/iiif/annotation/whatever.json'
       expect(response).to redirect_to('/1/iiif/annotation/whatever')
     end
+
+    it 'responds to OPTIONS requests' do
+      options '/bb157hs6068/iiif/manifest'
+      expect(response).to be_successful
+      expect(response.headers['Access-Control-Allow-Headers']).to include 'Accept'
+    end
   end
 
   context 'IIIF v3 requests' do
@@ -26,6 +40,17 @@ RSpec.describe 'PURL API', type: :request do
         headers: { 'Accept' => 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"' }
       )
       expect(response.body).to include 'http://iiif.io/api/presentation/3/context.json'
+    end
+
+    it 'responds to OPTIONS requests' do
+      options(
+        '/bb157hs6068/iiif/manifest',
+        params: {},
+        headers: { 'Accept' => 'application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"' }
+      )
+
+      expect(response).to be_successful
+      expect(response.headers['Access-Control-Allow-Headers']).to include 'Accept'
     end
 
     it 'redirects manifest.json requests' do


### PR DESCRIPTION
Follow-up to https://github.com/sul-dlss/purl/pull/271, which added support for content negotiation, but browers need an explicit invitation to perform it 🤷 .

This should unblock https://github.com/sul-dlss/sul-embed/pull/1256