### PR TITLE
Submit the feedback form and render flash messages

### DIFF
--- a/app/assets/javascripts/feedback_form.js
+++ b/app/assets/javascripts/feedback_form.js
@@ -43,7 +43,7 @@ $(document).on("turbolinks:load", function(){
               url: form.action,
               data: valuesToSubmit,
               type: 'post'
-            }).success(function(response){
+            }).done(function(response){
               if (isSuccess(response)){
                 $($el).collapse('hide');
                 $($form)[0].reset();
@@ -68,7 +68,7 @@ $(document).on("turbolinks:load", function(){
 
     function renderFlashMessages(response){
       $.each(response, function(i,val){
-        var flashHtml = "<div class='alert alert-" + val[0] + "'><button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;</button>" + val[1] + "</div>";
+        var flashHtml = "<div class='alert alert-" + val[0] + "'>" + val[1] + "<a class='close' data-dismiss='alert' href='#'>&times;</a></div>";
 
         // Show the flash message
         $('div.flash_messages').html(flashHtml);

--- a/app/assets/javascripts/feedback_form.js
+++ b/app/assets/javascripts/feedback_form.js
@@ -45,7 +45,11 @@ $(document).on("turbolinks:load", function(){
               type: 'post'
             }).done(function(response){
               if (isSuccess(response)){
-                $($el).collapse('hide');
+                // This is the BS5 way to collapse a div
+                var collapseElementList = [].slice.call(document.querySelectorAll('.collapse'))
+                var collapseList = collapseElementList.map(function (collapseEl) {
+                  return new bootstrap.Collapse(collapseEl)
+                })
                 $($form)[0].reset();
               }
               renderFlashMessages(response);
@@ -68,7 +72,7 @@ $(document).on("turbolinks:load", function(){
 
     function renderFlashMessages(response){
       $.each(response, function(i,val){
-        var flashHtml = "<div class='alert alert-" + val[0] + "'>" + val[1] + "<a class='close' data-dismiss='alert' href='#'>&times;</a></div>";
+        var flashHtml = "<div class='alert alert-" + val[0] + "'>" + val[1] + "<button type='button' class='btn-close' data-bs-dismiss='alert' aria-label='Close'></button></div>";
 
         // Show the flash message
         $('div.flash_messages').html(flashHtml);
@@ -107,7 +111,7 @@ $(document).on("turbolinks:load", function(){
           submitListener($el,$form);
 
           // Preventing link from triggering navigation
-          $('*[data-target="#' + this.element.id +'"]').on('click', function(e){
+          $('*[data-bs-target="#' + this.element.id +'"]').on('click', function(e){
             e.preventDefault();
           });
 

--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -1,4 +1,8 @@
 class FeedbackFormsController < ApplicationController
+  # The client handles rendering flash in this case, so clear it on the server
+  # side to prevent it from rendering on the next request.
+  after_action :discard_flash, only: :create, if: -> { request.xhr? }
+
   def new; end
 
   def create
@@ -28,5 +32,9 @@ class FeedbackFormsController < ApplicationController
     end
     flash[:error] = errors.join('<br/>') unless errors.empty?
     flash[:error].nil?
+  end
+
+  def discard_flash
+    flash.discard
   end
 end

--- a/app/views/_flash_msg.html.erb
+++ b/app/views/_flash_msg.html.erb
@@ -10,7 +10,7 @@
     -%>
     <% if flash[type] %>
       <div class="alert <%=alert_class %>"><%= flash[type].html_safe %>
-        <a class="close" data-dismiss="alert" href="#">&times;</a>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>
     <% end %>
   <% end %>

--- a/app/views/_flash_msg.html.erb
+++ b/app/views/_flash_msg.html.erb
@@ -1,0 +1,17 @@
+<div class="flash_messages">
+  <% [:success, :notice, :error, :alert].each do |type| %>
+    <%- alert_class = case type
+    when :success then "alert-success"
+    when :notice  then "alert-info"
+    when :alert   then "alert-warning"
+    when :error   then "alert-danger"
+    else "alert-#{type}"
+    end
+    -%>
+    <% if flash[type] %>
+      <div class="alert <%=alert_class %>"><%= flash[type].html_safe %>
+        <a class="close" data-dismiss="alert" href="#">&times;</a>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/errors/unavailable.html.erb
+++ b/app/views/errors/unavailable.html.erb
@@ -1,2 +1,2 @@
 <h2>The item you requested is not available.</h2>
-<p>This item is in processing or does not exist. If you believe you have reached this page in error, please send <%= link_to 'Feedback', feedback_path, data: {toggle:"collapse", target:"#feedback-form"} %>.</p>
+<p>This item is in processing or does not exist. If you believe you have reached this page in error, please send <%= link_to 'Feedback', feedback_path, data: { bs_toggle: 'collapse', bs_target: '#feedback-form' } %>.</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,7 @@
           <%= render 'shared/brand_navbar' %>
 
           <section id="main-container" role="main" data-analytics-id="<%= Settings.GOOGLE_ANALYTICS_ID %>">
+            <%= render partial: '/flash_msg', layout: 'shared/flash_messages' %>
             <%= yield %>
           </section>
         </div>

--- a/app/views/shared/_top_navbar.html.erb
+++ b/app/views/shared/_top_navbar.html.erb
@@ -6,7 +6,7 @@
       <%= image_tag "sul-logo-stacked.svg", class: "d-block d-sm-none", alt: "", height: 25 %>
     <% end %>
     <div class="header-links">
-      <%= link_to feedback_path, class: 'first', data: {toggle:"collapse", target:"#feedback-form"} do %>
+      <%= link_to feedback_path, class: 'first', data: { bs_toggle: 'collapse', bs_target: '#feedback-form' } do %>
         Feedback
       <% end if show_feedback_form? %>
     </div>

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -33,7 +33,7 @@
       <div class="form-group row">
         <div class="offset-sm-3 col-sm-9">
           <button type="submit" class="btn btn-primary">Send</button>
-          <%= link_to "Cancel", :back, class:"cancel-link", data: {toggle:"collapse", target:"#feedback-form"} %>
+          <%= link_to "Cancel", :back, class: 'cancel-link', data: { bs_toggle: 'collapse', bs_target: '#feedback-form' } %>
         </div>
       </div>
     </div>

--- a/babel.config.js
+++ b/babel.config.js
@@ -48,6 +48,12 @@ module.exports = function(api) {
         }
       ],
       [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true
+        }
+      ],
+      [
         '@babel/plugin-proposal-object-rest-spread',
         {
           useBuiltIns: true

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -3,7 +3,8 @@ const { environment } = require('@rails/webpacker')
 const webpack = require('webpack');
 environment.plugins.append('Provide', new webpack.ProvidePlugin({
   $: 'jquery',
-  jQuery: 'jquery'
+  jQuery: 'jquery',
+  bootstrap: 'bootstrap'
 }));
 
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "dependencies": {
+    "@popperjs/core": "^2.9.1",
     "@rails/webpacker": "5.2.1",
     "ace-builds": "^1.4.12",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^5.0.1",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
     "rails-ujs": "^5.2.4-5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,11 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@popperjs/core@^2.9.1":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+
 "@rails/webpacker@5.2.1":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-5.2.1.tgz#87cdbd4af2090ae2d74bdc51f6f04717d907c5b3"
@@ -1558,10 +1563,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bootstrap@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"
-  integrity sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==
+bootstrap@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.1.tgz#e7939d599119dc818a90478a2a299bdaff037e09"
+  integrity sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Connects to #487

This PR wires up the client-side feedback form such that when a user submits it, one or more flash messages successfully render on the screen. It has three components:

1. Render the flash_messages partial (it was not rendering at all before so the user received no feedback, which I suspect is/was leading to duplicate form submissions);
2. Correct the selector in the client-side feedback code to point at the right div selector for flashes; and
3. Use the `.done()` callback on the AJAX request that submits the form, as `.success()` seems to no longer be defined (at least, I was seeing local errors in the JS console...)

I could not otherwise reproduce this bug, so I am hesitant to say this fixes #487 but maaaaaybe it does if the source is user confusion leading to double submits.