### PR TITLE
Relayout the feedback form for consistency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ gem 'sass-rails', '>= 6.0'
 gem 'uglifier', '>= 2.7.2'
 # A gem for simple rails environment specific config
 gem 'config'
-# Use jquery as the JavaScript library
-gem 'jquery-rails'
 
 gem 'turbolinks', '~> 5'
 
@@ -48,6 +46,9 @@ gem 'addressable'
 gem 'tophat'
 gem 'rails-file-icons'
 gem 'sul_styles', '~> 0.6'
+
+# Use recaptcha gem to prevent robots spamming the feedback form
+gem 'recaptcha'
 
 # sul-dlss/osullivan#development has early support for generating IIIF v3 manifests
 gem 'iiif-presentation', github: 'sul-dlss/osullivan', branch: 'development'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,10 +195,6 @@ GEM
     iso-639 (0.3.5)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
-    jquery-rails (4.4.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.5.1)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -288,6 +284,8 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    recaptcha (5.8.0)
+      json
     regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -438,7 +436,6 @@ DEPENDENCIES
   htmlentities
   iiif-presentation!
   jbuilder (~> 2.5)
-  jquery-rails
   listen
   lograge
   mods_display (~> 0.4)
@@ -447,6 +444,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 6.0)
   rails-file-icons
+  recaptcha
   rspec-rails (~> 5.0)
   rubocop
   rubocop-performance
@@ -470,4 +468,4 @@ DEPENDENCIES
   webpacker (~> 5.x)
 
 BUNDLED WITH
-   2.2.15
+   2.2.19

--- a/app/assets/javascripts/feedback_form.js
+++ b/app/assets/javascripts/feedback_form.js
@@ -1,12 +1,10 @@
 $(document).on("turbolinks:load", function(){
-
-  //Instantiates plugin for feedback form
+  // Instantiates plugin for feedback form
 
   $("#feedback-form").feedbackForm();
-})
+});
 
-
-;(function ( $, window, document, undefined ) {
+(function ($, window, document, undefined) {
   /*
     jQuery plugin that handles some of the feedback form functionality
 
@@ -15,23 +13,22 @@ $(document).on("turbolinks:load", function(){
     No available options
 
     This plugin :
-      - changes feedback form link to button
       - submits an ajax request for the feedback form
       - displays alert on response from feedback form
   */
 
     var pluginName = "feedbackForm";
 
-    function Plugin( element, options ) {
+    function Plugin(element, options) {
         this.element = element;
         var $el, $form;
 
-        this.options = $.extend( {}, options) ;
+        this.options = $.extend({}, options);
         this._name = pluginName;
         this.init();
     }
 
-    function submitListener(){
+    function submitListener() {
       // Serialize and submit form if not on action url
       $form.each(function(i, form){
         if (location !== form.action){
@@ -45,11 +42,8 @@ $(document).on("turbolinks:load", function(){
               type: 'post'
             }).done(function(response){
               if (isSuccess(response)){
-                // This is the BS5 way to collapse a div
-                var collapseElementList = [].slice.call(document.querySelectorAll('.collapse'))
-                var collapseList = collapseElementList.map(function (collapseEl) {
-                  return new bootstrap.Collapse(collapseEl)
-                })
+                // This is the BS5 way to toggle a collapsible
+                new bootstrap.Collapse($el);
                 $($form)[0].reset();
               }
               renderFlashMessages(response);
@@ -70,56 +64,41 @@ $(document).on("turbolinks:load", function(){
       }
     }
 
-    function renderFlashMessages(response){
+    function renderFlashMessages(response) {
       $.each(response, function(i,val){
-        var flashHtml = "<div class='alert alert-" + val[0] + "'>" + val[1] + "<button type='button' class='btn-close' data-bs-dismiss='alert' aria-label='Close'></button></div>";
+        var flashHtml = "<div class='alert alert-" + alertClassFrom(val[0]) + " alert-dismissible' role='alert'>" + val[1] + "<button type='button' class='btn-close' data-bs-dismiss='alert' aria-label='Close'></button></div>";
 
         // Show the flash message
         $('div.flash_messages').html(flashHtml);
       });
     }
 
-    function replaceLink(form, link) {
-      var attrs = {};
-      $.each(link[0].attributes, function(idx, attr) {
-          attrs[attr.nodeName] = attr.value;
-      });
-      attrs.class = 'cancel-link btn btn-link';
-
-      // Replace the cancel link with a button
-      link.replaceWith(function() {
-        return $('<button />', attrs).append($(this).contents());
-      });
-
-      // Cancel link should not submit form
-      form.find('button.cancel-link').on('click', function(e){
-        e.preventDefault();
-      });
+    function alertClassFrom(flashLevel) {
+      switch(flashLevel) {
+      case 'notice':
+        return 'info';
+      case 'alert':
+        return 'warning';
+      case 'error':
+        return 'danger';
+      default:
+        return flashLevel;
+      }
     }
 
     Plugin.prototype = {
-
         init: function() {
           $el = $(this.element);
           $form = $($el).find('form');
-          $cancelLink = $($el).find(".cancel-link");
 
-          // Replace "Cancel" link with link styled button
-          replaceLink($el, $cancelLink);
+          // Add listener for form submit
+          submitListener();
 
-          //Add listener for form submit
-          submitListener($el,$form);
-
-          // Preventing link from triggering navigation
-          $('*[data-bs-target="#' + this.element.id +'"]').on('click', function(e){
-            e.preventDefault();
-          });
-
-          //Updates reporting from fields for current location
+          // Updates reporting from fields for current location
           $('span.reporting-from-field').html(location.href);
           $('input.reporting-from-field').val(location.href);
 
-          // Listen for form open and then add focus to message
+          // Focus message textarea when showing collapsible form
           $('#feedback-form').on('shown.bs.collapse', function () {
             $("textarea#message").focus();
           });
@@ -128,13 +107,12 @@ $(document).on("turbolinks:load", function(){
 
     // A really lightweight plugin wrapper around the constructor,
     // preventing against multiple instantiations
-    $.fn[pluginName] = function ( options ) {
+    $.fn[pluginName] = function (options) {
         return this.each(function () {
             if (!$.data(this, "plugin_" + pluginName)) {
                 $.data(this, "plugin_" + pluginName,
-                new Plugin( this, options ));
+                new Plugin(this, options));
             }
         });
     };
-
-})( jQuery, window, document );
+})(jQuery, window, document);

--- a/app/assets/stylesheets/modules/feedback-form.scss
+++ b/app/assets/stylesheets/modules/feedback-form.scss
@@ -1,9 +1,9 @@
-.cancel-link .btn .btn-link {
-  margin-left:12px;
+.btn .btn-link {
+  margin-left: 12px;
   border-bottom: none;
 }
 
-#feedback-form{
+#feedback-form {
   border-bottom: 3px solid $sul-toolbar-border;
 }
 

--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -1,7 +1,13 @@
+# frozen_string_literal: true
+
 class FeedbackFormsController < ApplicationController
+  EMAIL_PRESENT_MESSAGE = 'You have filled in a field that makes you appear as a spammer.  Please follow the directions for the individual form fields.'
+  MESSAGE_BLANK_MESSAGE = 'A message is required'
+  RECAPTCHA_MESSAGE = 'You must pass the reCAPTCHA challenge'
+
   # The client handles rendering flash in this case, so clear it on the server
   # side to prevent it from rendering on the next request.
-  after_action :discard_flash, only: :create, if: -> { request.xhr? }
+  after_action :discard_flash!, only: :create, if: -> { request.xhr? }
 
   def new; end
 
@@ -25,16 +31,15 @@ class FeedbackFormsController < ApplicationController
 
   def validate
     errors = []
-    errors << 'A message is required' if params[:message].blank?
+    errors << MESSAGE_BLANK_MESSAGE if params[:message].blank?
+    errors << EMAIL_PRESENT_MESSAGE if params[:email_address].present?
+    errors << RECAPTCHA_MESSAGE if current_user.blank? && !verify_recaptcha
 
-    if params[:email_address].present?
-      errors << 'You have filled in a field that makes you appear as a spammer.  Please follow the directions for the individual form fields.'
-    end
     flash[:error] = errors.join('<br/>') unless errors.empty?
     flash[:error].nil?
   end
 
-  def discard_flash
+  def discard_flash!
     flash.discard
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,4 +1,3 @@
-/* eslint no-console:0 */
 // This file is automatically compiled by Webpack, along with any other files
 // present in this directory. You're encouraged to place your actual application logic in
 // a relevant structure within app/javascript and only use these pack files to reference
@@ -6,7 +5,6 @@
 //
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
-
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
@@ -17,9 +15,10 @@
 
 import Rails from 'rails-ujs';
 import Turbolinks from 'turbolinks';
-import 'bootstrap/dist/js/bootstrap';
+import 'jquery';
 import 'jquery.oembed.js';
 import 'jQuery.XDomainRequest.js';
+import 'bootstrap';
 
 Rails.start();
 Turbolinks.start();

--- a/app/views/_flash_msg.html.erb
+++ b/app/views/_flash_msg.html.erb
@@ -9,7 +9,7 @@
     end
     -%>
     <% if flash[type] %>
-      <div class="alert <%=alert_class %>"><%= flash[type].html_safe %>
+      <div class="alert <%=alert_class %> alert-dismissible" role="alert"><%= flash[type].html_safe %>
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>
     <% end %>

--- a/app/views/shared/feedback_forms/_form.html.erb
+++ b/app/views/shared/feedback_forms/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="col-sm-6 my-3">
   <%= form_tag feedback_form_path, method: :post, class:"form-horizontal feedback-form", role:"form" do %>
     <div class="row">
-      <div class="offset-sm-3 col-sm-9 px-4 mb-2">
+      <div class="col-sm-12 px-4 mb-2">
         <%= render "shared/feedback_forms/reporting_from" %>
       </div>
     </div>
@@ -13,27 +13,36 @@
     </span>
     <div class="mx-3">
       <div class="form-group row mb-3">
-        <%= label_tag(:message, 'Message', class:"col-sm-3 col-form-label") %>
+        <%= label_tag(:message, 'Message', class: "col-sm-3 col-form-label text-end") %>
         <div class="col-sm-9">
           <%= text_area_tag :message, "", rows:"5", class:"form-control" %>
         </div>
       </div>
       <div class="form-group row mb-3">
-        <%= label_tag(:name, 'Your name', class:"col-sm-3 col-form-label") %>
+        <%= label_tag(:name, 'Your name', class: "col-sm-3 col-form-label text-end") %>
         <div class="col-sm-9">
           <%= text_field_tag :name, "", class:"form-control" %>
         </div>
       </div>
       <div class="form-group row mb-3">
-        <%= label_tag(:to, 'Your email', class:"col-sm-3 col-form-label") %>
+        <%= label_tag(:to, 'Your email', class: "col-sm-3 col-form-label text-end") %>
         <div class="col-sm-9">
           <%= email_field_tag :to, "", class:"form-control" %>
         </div>
       </div>
+      <% if current_user.blank? %>
+        <div class="form-group row mb-3">
+          <div class="offset-sm-3 col-sm-9">
+            <%= recaptcha_tags %>
+
+            <p>(Stanford users can avoid this Captcha by logging in.)</p>
+          </div>
+        </div>
+      <% end %>
       <div class="form-group row">
         <div class="offset-sm-3 col-sm-9">
           <button type="submit" class="btn btn-primary">Send</button>
-          <%= link_to "Cancel", :back, class: 'cancel-link', data: { bs_toggle: 'collapse', bs_target: '#feedback-form' } %>
+          <%= button_tag "Cancel", type: 'button', class: 'btn btn-link', data: { bs_toggle: 'collapse', bs_target: '#feedback-form' }, aria: { expanded: false, controls: 'feedback-form' }  %>
         </div>
       </div>
     </div>

--- a/app/views/shared/feedback_forms/_reporting_from.html.erb
+++ b/app/views/shared/feedback_forms/_reporting_from.html.erb
@@ -1,2 +1,4 @@
-Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
-<%= hidden_field_tag :url, request.referer, class:"reporting-from-field" %>
+<div class="alert alert-info" role="alert">
+  Reporting from: <span class="reporting-from-field"><%= request.referer %></span>
+  <%= hidden_field_tag :url, request.referer, class:"reporting-from-field" %>
+</div>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Recaptcha.configure do |config|
+  config.site_key = Settings.recaptcha.site_key
+  config.secret_key = Settings.recaptcha.secret_key
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,7 +5,7 @@ stacks:
 content_search:
   url:
 
-document_cache_root: "<%= File.join(Rails.root, "document_cache") %>"
+document_cache_root: "<%= File.join(Rails.root, 'document_cache') %>"
 
 resource_cache:
   enabled: true
@@ -74,3 +74,7 @@ GOOGLE_ANALYTICS_ID: "X-123"
 
 twitter:
   site: '@DigitalLib'
+
+recaptcha:
+  site_key: 6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy
+  secret_key: 6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -2,8 +2,8 @@ const { environment } = require('@rails/webpacker')
 
 const webpack = require('webpack');
 environment.plugins.append('Provide', new webpack.ProvidePlugin({
-  $: 'jquery',
-  jQuery: 'jquery',
+  $: 'jquery/src/jquery',
+  jQuery: 'jquery/src/jquery',
   bootstrap: 'bootstrap'
 }));
 

--- a/spec/controller/feedback_forms_controller_spec.rb
+++ b/spec/controller/feedback_forms_controller_spec.rb
@@ -4,26 +4,52 @@ describe FeedbackFormsController, type: :controller do
   before do
     allow(Settings.feedback).to receive(:email_to).and_return('feedback@example.com')
   end
+
   describe 'format json' do
-    it 'should return json success' do
+    it 'returns json success' do
       post :create, params: { url: 'http://test.host/', message: 'Hello Kittenz', format: 'json' }
       expect(flash[:success]).to eq 'Thank you! Your feedback has been sent.'
     end
 
-    it 'should return html success' do
+    it 'returns html success' do
       post :create, params: { url: 'http://test.host/', message: 'Hello Kittenz' }
       expect(flash[:success]).to eq 'Thank you! Your feedback has been sent.'
     end
   end
+
   describe 'validate' do
-    it 'should return an error if no message is sent' do
+    it 'returns an error if no message is sent' do
       post :create, params: { url: 'http://test.host/', message: '', email_address: '' }
-      expect(flash[:error]).to eq 'A message is required'
+      expect(flash[:error]).to eq FeedbackFormsController::MESSAGE_BLANK_MESSAGE
     end
 
-    it 'should return an error if a bot fills in the email_address field (email is correct field)' do
+    it 'returns an error if a bot fills in the email_address field (email is correct field)' do
       post :create, params: { message: 'I am spamming you!', url: 'http://test.host/', email_address: 'spam!' }
-      expect(flash[:error]).to eq 'You have filled in a field that makes you appear as a spammer.  Please follow the directions for the individual form fields.'
+      expect(flash[:error]).to eq FeedbackFormsController::EMAIL_PRESENT_MESSAGE
+    end
+
+    context 'when the user is not logged in' do
+      before do
+        allow(controller).to receive(:verify_recaptcha).and_return(false)
+      end
+
+      it 'returns an error if the recaptcha is incorrect' do
+        post :create, params: { message: 'I am spamming you!', url: 'http://test.host/' }
+        expect(flash[:error]).to eq FeedbackFormsController::RECAPTCHA_MESSAGE
+      end
+    end
+
+    context 'when the user is logged in' do
+      before do
+        allow(controller).to receive(:current_user).and_return('any truthy value, really')
+        allow(controller).to receive(:verify_recaptcha)
+      end
+
+      it 'does not care if the recaptcha is incorrect' do
+        post :create, params: { message: 'I am spamming you!', url: 'http://test.host/' }
+        expect(flash[:error]).to be_nil
+        expect(controller).not_to have_received(:verify_recaptcha)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #421

This commit contains a number of changes related to tweaking the layout of the feedback form:

* Requested style changes (see screenshots)
* As part of moving to Bootstrap 5, manage jquery via webpacker which gives us more control over load order (JQuery must be loaded before Bootstrap or BS controls do not function---to wit, the collapsible div is currently broken in deployed environments such that it only collapses when submitted not when cancelled)
* Use recaptcha gem to support ReCAPTCHA use case for unauthenticated users
* Minor JavaScript formatting tweaks
* Remove code from feedback_forms.js that doesn't seem necessary anymore, including the link-to-button functionality
* Fix the styling of BS alerts generated from within javascript (currently, error flashes are unstyled)
* Embangify a private method in FeedbackFormsController (stylistic only)
* Load JQuery before Bootstrap in webpacker config

# Screencast

![Peek 2021-06-08 14-33](https://user-images.githubusercontent.com/131982/121263819-1556d480-c86b-11eb-849e-5eedf19031ab.gif)


# Screenshots

## BEFORE

![before](https://user-images.githubusercontent.com/131982/121263849-1ab41f00-c86b-11eb-83c0-467f4e13ca61.png)


## AFTER

![after](https://user-images.githubusercontent.com/131982/121263857-1d167900-c86b-11eb-9aee-fc74b94c9c44.png)
