### PR TITLE
Display multivalued abstract/contents as multiple paragraphs

### DIFF
--- a/app/views/purl/_mods_abstract_contents.html.erb
+++ b/app/views/purl/_mods_abstract_contents.html.erb
@@ -12,7 +12,7 @@
   <% if contents.respond_to?(:values) %>
     <%= mods_display_label(contents.label) %>
     <dd class="section-contents">
-      <%= simple_format contents.values.join.gsub('&#10;', "\n").html_safe, {}, sanitize: false %>
+      <%= simple_format contents.values.join("\n\n").gsub('&#10;', "\n").html_safe, {}, sanitize: false %>
     </dd>
   <% end %>
 <% end %>

--- a/app/views/purl/_mods_abstract_contents.html.erb
+++ b/app/views/purl/_mods_abstract_contents.html.erb
@@ -3,7 +3,7 @@
   <% if abstracts.respond_to?(:values) %>
     <%= mods_display_label(abstracts.label) %>
     <dd class="section-abstract">
-      <%= simple_format abstracts.values.join.gsub('&#10;', "\n").html_safe, {}, sanitize: false %>
+      <%= simple_format abstracts.values.join("\n\n").gsub('&#10;', "\n").html_safe, {}, sanitize: false %>
     </dd>
   <% end %>
 <% end %>


### PR DESCRIPTION
Joining the abstract field on a double newline causes simple_format
to begin a new paragraph tag. Previously, we concatenated the
abstract field without any delimiter.

See https://github.com/sul-dlss/mods_display/issues/54

example item with multivalued abstract: https://purl.stanford.edu/fr878dp2426