### PR TITLE
Initalize javascript at the top level

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,5 +4,11 @@ import 'jQuery.XDomainRequest';
 import 'bootstrap';
 
 import 'feedback_form';
-import 'purl_embed';
+import Embed from 'purl_embed';
+import jQuery from 'jquery'
+
+window.addEventListener("load", () => {
+  Embed.init(jQuery)
+})
+
 import('analytics'); // Dynamically import, so that a content-blocker doesn't break the scripts

--- a/app/javascript/purl_embed.js
+++ b/app/javascript/purl_embed.js
@@ -1,7 +1,5 @@
-import jQuery from 'jquery'
-
-(function ($) {
-  document.addEventListener("DOMContentLoaded", function () {
+const Embed = {
+  init: function($) {
     $("a.embed").each(function () {
       $.fn.oembed.providers = [
         new $.fn.oembed.OEmbedProvider(
@@ -15,5 +13,7 @@ import jQuery from 'jquery'
 
       $(this).oembed();
     });
-  }, { once: true })
-})(jQuery);
+  }
+}
+
+export default Embed;


### PR DESCRIPTION
Window load event happens after the resources are loaded, rather than DOMContentLoaded, which happens too early https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event