### PR TITLE
Remove dalli gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,11 +63,6 @@ gem 'recaptcha'
 
 # sul-dlss/osullivan#development has early support for generating IIIF v3 manifests
 gem 'iiif-presentation', github: 'sul-dlss/osullivan', branch: 'development'
-gem 'dalli'
-
-# connection_pool required for thread-safe operations in dalli >= 3.0
-# see https://github.com/petergoldstein/dalli/blob/v3.0.0/3.0-Upgrade.md
-gem 'connection_pool'
 
 group :production do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,9 +127,7 @@ GEM
     config (4.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    connection_pool (2.3.0)
     crass (1.0.6)
-    dalli (3.2.3)
     date (3.3.3)
     debug (1.7.1)
       irb (>= 1.5.0)
@@ -447,8 +445,6 @@ DEPENDENCIES
   capistrano-shared_configs
   capybara
   config
-  connection_pool
-  dalli
   debug
   dlss-capistrano
   dor-rights-auth (~> 1.6)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -15,9 +15,6 @@ OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new
 OkComputer::Registry.register 'document_cache_root',
   OkComputer::DirectoryCheck.new(Settings.document_cache_root)
 
-# Check the memcache servers used by Rails.cache
-OkComputer::Registry.register 'rails_cache', OkComputer::GenericCacheCheck.new
-
 # NOTE:
 # Settings.purl_resource.public_xml, Settings.purl_resource.mods, and Settings.purl_resource.iiif_manifest
 #   exist in the document cache root on deployed environments.


### PR DESCRIPTION
Dalli is used for memcached, but we stopped using this two years ago