### PR TITLE
Fix feedback form javascript

### DIFF
--- a/app/javascript/feedback_form.js
+++ b/app/javascript/feedback_form.js
@@ -1,3 +1,4 @@
+import { Collapse } from 'bootstrap'
 import jQuery from 'jquery'
 const $ = jQuery
 
@@ -79,6 +80,8 @@ $(function(){
         },
 
         submitListener: function () {
+          const el = this.$el;
+
           // Serialize and submit form if not on action url
           this.$form.each(function(i, form){
             if (location !== form.action){
@@ -93,8 +96,8 @@ $(function(){
                 }).done(function(response){
                   if (isSuccess(response)){
                     // This is the BS5 way to toggle a collapsible
-                    new bootstrap.Collapse(this.$el);
-                    this.$form[0].reset();
+                    new Collapse(el);
+                    form.reset();
                   }
                   renderFlashMessages(response);
                 });


### PR DESCRIPTION
Fixes reported issue where feedback is submitted but the form stays open and success message never appears. Addresses the following errors:

- `Uncaught ReferenceError: Collapse is not defined`
- `this.$el `is undefined when called
- `this.$form[0]` is undefined when called