### PR TITLE
Do not show a second feedback form on the feedback page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   end
 
   def show_feedback_form?
-    Settings.feedback.email_to.present?
+    Settings.feedback.email_to.present? && !current_page?(feedback_path)
   end
 
   def link_to_purl(druid)


### PR DESCRIPTION
This fixes an accessability issue where the form  elements do not have unique ids