### PR TITLE
Add js install step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Move into the app and install dependencies
 
     $ cd purl
     $ bundle install
+    $ yarn
 
 Start the development server
 


### PR DESCRIPTION
The README doesn't include the step to install JS dependencies; without it `bin/dev` will fail.