### PR TITLE
Set up analytics tracking with ahoy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ group :development, :test do
 
   gem 'selenium-webdriver', '!= 3.13.0'
   gem 'simplecov', require: false
+
+  # Database cleaner allows us to clean the entire database after certain tests
+  gem 'database_cleaner'
 end
 
 group :deployment do

--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,6 @@ group :deployment do
   gem 'dlss-capistrano'
 end
 
+gem "cssbundling-rails", "~> 1.1"
+
+gem "ahoy_matey", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,12 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.2.0)
       railties (>= 6.0.0)
+    database_cleaner (2.0.2)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.1.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
@@ -417,6 +423,7 @@ DEPENDENCIES
   capybara
   config
   cssbundling-rails (~> 1.1)
+  database_cleaner
   debug
   dlss-capistrano
   dor-rights-auth (~> 1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,10 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
+    ahoy_matey (5.0.2)
+      activesupport (>= 6.1)
+      device_detector (>= 1)
+      safely_block (>= 0.4)
     airbrussh (1.4.2)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
@@ -120,6 +124,7 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     deep_merge (1.2.2)
+    device_detector (1.1.1)
     diff-lcs (1.5.0)
     dlss-capistrano (4.4.0)
       capistrano (~> 3.0)
@@ -337,6 +342,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    safely_block (0.4.0)
     selenium-webdriver (4.12.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -400,6 +406,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
+  ahoy_matey (~> 5.0)
   bootsnap (>= 1.1.0)
   cancancan
   capistrano (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -50,3 +50,21 @@ The RuboCop style enforcement can be run without running the tests
 ## Deploying
 
 Deployment is handled automatically via Jenkins when a release is published to GitHub.
+
+## Analytics
+
+Analytics are collected via both Google Analytics and [ahoy](https://github.com/ankane/ahoy).
+
+When in local development, you may find it useful to fake analytics events as though they had been triggered by sul-embed. If `analytics_debug` is set to `true` in your Rails config, the [ahoy.js](https://github.com/ankane/ahoy.js) library will be loaded onto each page.
+
+You can then trigger analytics events by calling `ahoy.track` in the browser console. For example:
+```js
+ahoy.trackView({ druid: "abc123" });
+```
+
+To trigger a download event:
+```js
+ahoy.track("download", { druid: "abc123" });
+```
+
+The `druid` parameter is required to associate the events with a particular `PurlResource` object.

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -1,0 +1,11 @@
+module Ahoy
+  class Event < ApplicationRecord
+    include Ahoy::QueryMethods
+
+    self.table_name = 'ahoy_events'
+
+    belongs_to :visit
+
+    serialize :properties, JSON
+  end
+end

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -1,0 +1,7 @@
+module Ahoy
+  class Visit < ApplicationRecord
+    self.table_name = 'ahoy_visits'
+
+    has_many :events, class_name: 'Ahoy::Event', dependent: :nullify
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -125,6 +125,22 @@ class PurlResource
     object_type == 'collection'
   end
 
+  def view_count
+    views.count
+  end
+
+  def unique_view_count
+    views.distinct.count('visit_id')
+  end
+
+  def download_count
+    downloads.count
+  end
+
+  def unique_download_count
+    downloads.distinct.count('visit_id')
+  end
+
   concerning :Metadata do
     def title
       if mods?
@@ -292,5 +308,13 @@ class PurlResource
 
   def logger
     Rails.logger
+  end
+
+  def views
+    Ahoy::Event.where_event('$view', druid:)
+  end
+
+  def downloads
+    Ahoy::Event.where_event('download', druid:)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,11 @@
       gtag('config', 'G-B11RSRZLRJ', config)
     </script>
 
+    <!-- ahoy.js analytics (debug use only) -->
+    <% if Settings.analytics_debug %>
+      <script src="https://unpkg.com/ahoy.js"></script>
+    <% end %>
+
     <%= title site: application_name, separator: '|', reverse: true %>
 
     <%= favicon_link_tag 'favicon.ico' %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,22 +1,25 @@
 # SQLite version 3.x
-#   gem install sqlite3-ruby (not necessary on OS X Leopard)
-development:
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+#
+default: &default
   adapter: sqlite3
-  database: db/development.sqlite3
   pool: 5
   timeout: 5000
+
+development:
+  <<: *default
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
+  <<: *default
   database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
 
 production:
-  adapter: sqlite3
+  <<: *default
   database: db/production.sqlite3
-  pool: 5
-  timeout: 5000

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -1,0 +1,16 @@
+# https://github.com/ankane/ahoy
+
+class Ahoy::Store < Ahoy::DatabaseStore
+end
+
+# enable the API for tracking events client-side via sul-embed
+Ahoy.api = true
+
+# only create a visit object server-side once events are logged via JS
+Ahoy.server_side_visits = :when_needed
+
+# mask IPs by setting the last octet to 0
+Ahoy.mask_ips = true
+
+# enable event logging in development
+Ahoy.quiet = !Rails.env.development?

--- a/config/initializers/safely.rb
+++ b/config/initializers/safely.rb
@@ -1,0 +1,3 @@
+# https://github.com/ankane/safely
+
+Safely.report_exception_method = ->(e) { Honeybadger.notify(e) }

--- a/db/migrate/20231024215032_create_ahoy_visits_and_events.rb
+++ b/db/migrate/20231024215032_create_ahoy_visits_and_events.rb
@@ -1,0 +1,57 @@
+class CreateAhoyVisitsAndEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :ahoy_visits do |t|
+      t.string :visit_token
+      t.string :visitor_token
+
+      # the rest are recommended but optional
+      # simply remove any you don't want
+
+      # standard
+      t.string :ip
+      t.text :user_agent
+      t.text :referrer
+      t.string :referring_domain
+      t.text :landing_page
+
+      # technology
+      t.string :browser
+      t.string :os
+      t.string :device_type
+
+      # location
+      t.string :country
+      t.string :region
+      t.string :city
+      t.float :latitude
+      t.float :longitude
+
+      # utm parameters
+      t.string :utm_source
+      t.string :utm_medium
+      t.string :utm_term
+      t.string :utm_content
+      t.string :utm_campaign
+
+      # native apps
+      t.string :app_version
+      t.string :os_version
+      t.string :platform
+
+      t.datetime :started_at
+    end
+
+    add_index :ahoy_visits, :visit_token, unique: true
+    add_index :ahoy_visits, [:visitor_token, :started_at]
+
+    create_table :ahoy_events do |t|
+      t.references :visit
+
+      t.string :name
+      t.text :properties
+      t.datetime :time
+    end
+
+    add_index :ahoy_events, [:name, :time]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,52 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_10_24_215032) do
+  create_table "ahoy_events", force: :cascade do |t|
+    t.integer "visit_id"
+    t.string "name"
+    t.text "properties"
+    t.datetime "time"
+    t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
+  end
+
+  create_table "ahoy_visits", force: :cascade do |t|
+    t.string "visit_token"
+    t.string "visitor_token"
+    t.string "ip"
+    t.text "user_agent"
+    t.text "referrer"
+    t.string "referring_domain"
+    t.text "landing_page"
+    t.string "browser"
+    t.string "os"
+    t.string "device_type"
+    t.string "country"
+    t.string "region"
+    t.string "city"
+    t.float "latitude"
+    t.float "longitude"
+    t.string "utm_source"
+    t.string "utm_medium"
+    t.string "utm_term"
+    t.string "utm_content"
+    t.string "utm_campaign"
+    t.string "app_version"
+    t.string "os_version"
+    t.string "platform"
+    t.datetime "started_at"
+    t.index ["visit_token"], name: "index_ahoy_visits_on_visit_token", unique: true
+    t.index ["visitor_token", "started_at"], name: "index_ahoy_visits_on_visitor_token_and_started_at"
+  end
+
+end

--- a/spec/model/purl_resource_spec.rb
+++ b/spec/model/purl_resource_spec.rb
@@ -367,4 +367,38 @@ RSpec.describe PurlResource do
       end
     end
   end
+
+  describe 'analytics' do
+    let(:visit) { Ahoy::Visit.create(started_at: Time.zone.now - 1.day) }
+
+    before do
+      5.times { Ahoy::Event.create(visit:, name: '$view', properties: { druid: 'bb051dp0564' }) }
+      2.times { Ahoy::Event.create(visit:, name: 'download', properties: { druid: 'bb051dp0564' }) }
+      allow(subject).to receive(:druid).and_return('bb051dp0564')
+    end
+
+    describe '#view_count' do
+      it 'is the total number of view events for the druid' do
+        expect(subject.view_count).to eq 5
+      end
+    end
+
+    describe '#unique_view_count' do
+      it 'is the number of visits with at least one view for the druid' do
+        expect(subject.unique_view_count).to eq 1
+      end
+    end
+
+    describe '#download_count' do
+      it 'is the total number of download events for a purl' do
+        expect(subject.download_count).to eq 2
+      end
+    end
+
+    describe '#unique_download_count' do
+      it 'is the number of visits with at least one download for the druid' do
+        expect(subject.unique_download_count).to eq 1
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,27 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
+  # Clean up the database for each test
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before do
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
Closes #720 

- Set up Ahoy for analytics tracking
- Set up a SQLite database for tracking analytics
- Add view and download tracking accessors to PurlResource

See the changes to the README for an explanation of how to fake analytics events in local development.