### PR TITLE
ORCID IDs displayed on purl page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # DLSS and its community
 gem 'dor-rights-auth', '~> 1.6'
 gem 'iiif-presentation', '~> 1.2'
-gem 'mods_display', '~> 1.1'
+gem 'mods_display', '~> 1.1', '>= 1.3.2' # orcid support
 
 group :production do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,9 +210,10 @@ GEM
       iso-639
       nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
-    mods_display (1.3.1)
+    mods_display (1.3.2)
       i18n
-      stanford-mods (~> 3.3)
+      rails_autolink
+      stanford-mods (~> 3.3, >= 3.3.7)
       view_component
     msgpack (1.7.2)
     net-imap (0.3.7)
@@ -272,6 +273,10 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails_autolink (1.1.8)
+      actionview (> 3.1)
+      activesupport (> 3.1)
+      railties (> 3.1)
     railties (7.0.7.2)
       actionpack (= 7.0.7.2)
       activesupport (= 7.0.7.2)
@@ -377,7 +382,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    view_component (3.5.0)
+    view_component (3.6.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -419,7 +424,7 @@ DEPENDENCIES
   iiif-presentation (~> 1.2)
   importmap-rails
   jbuilder
-  mods_display (~> 1.1)
+  mods_display (~> 1.1, >= 1.3.2)
   newrelic_rpm
   okcomputer
   puma (~> 5.0)

--- a/app/assets/stylesheets/modules/record-metadata-section.scss
+++ b/app/assets/stylesheets/modules/record-metadata-section.scss
@@ -32,6 +32,11 @@
   }
 }
 
+#contributors dd {
+  display: flex;
+  justify-content: space-between;
+}
+
 // Based on sul-embed
 .stanford-only-text {
   background: url('stanford_s.png') no-repeat left;

--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -199,7 +199,7 @@ class PurlResource
 
     # @return [String,nil] DOI (with https://doi.org/ prefix) if present
     def doi
-      @doi ||= mods_document.root&.at_xpath('mods:identifier[@type="doi"]', mods: 'http://www.loc.gov/mods/v3')&.text
+      @doi ||= mods_ng_document.root&.at_xpath('mods:identifier[@type="doi"]', mods: 'http://www.loc.gov/mods/v3')&.text
     end
 
     # @return [String,nil] DOI (without https://doi.org/ prefix) if present
@@ -286,8 +286,8 @@ class PurlResource
     @mods_display_object ||= ModsDisplay::Record.new(mods_body)
   end
 
-  def mods_document
-    @mods_document ||= Nokogiri::XML(mods_body)
+  def mods_ng_document
+    @mods_ng_document ||= Nokogiri::XML(mods_body)
   end
 
   def logger

--- a/app/views/purl/_mods_contributors.html.erb
+++ b/app/views/purl/_mods_contributors.html.erb
@@ -5,8 +5,21 @@
     </div>
     <div class="section-body">
       <dl>
-        <% document.mods.name.each do |name| %>
-          <%= mods_name_field(name) %>
+        <% document.mods.name.each do |role_with_names| %>
+          <%= mods_record_field(role_with_names) do |name| %>
+            <% capture do %>
+              <%= name.name %>
+              <% if name.orcid.present? %>
+                <span class="orcid">
+                  <% orcid_url = "https://orcid.org/#{name.orcid}" %>
+                  <a href="<%= orcid_url %>" aria-label="view ORCID page for <%= name.name %>">
+                    <img alt="ORCiD icon" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
+                    <%= orcid_url %>
+                  </a> (unverified)
+                </span>
+              <% end %>
+            <% end %>
+          <% end %>
         <% end %>
       </dl>
     </div>

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -179,6 +179,21 @@ RSpec.describe 'Integration Scenarios' do
     end
   end
 
+  context 'item with ORCID for some contributors' do
+    it 'adds ORCID links' do
+      visit '/wm135gp2721'
+
+      expect(page).to have_text(%r{Schroeder, Dustin\s+https://orcid.org/0000-0003-1916-3929\s*\(unverified\)})
+      orcid_link = page.find_link('https://orcid.org/0000-0003-1916-3929') # text of link
+      expect(orcid_link['href']).to eq 'https://orcid.org/0000-0003-1916-3929'
+      expect(orcid_link['aria-label']).to eq('view ORCID page for Schroeder, Dustin')
+
+      icons = page.all('img[alt="ORCiD icon"]')
+      expect(icons.size).to eq 3
+      icons.each { |icon| expect(icon['src']).to eq 'https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png' }
+    end
+  end
+
   def have_metadata_section(text)
     have_selector '.section-heading', text:
   end

--- a/spec/fixtures/document_cache/wm/135/gp/2721/mods
+++ b/spec/fixtures/document_cache/wm/135/gp/2721/mods
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+  <titleInfo>
+    <title>A Newly Digitised Ice-penetrating Radar Dataset Acquired over the Greenland Ice Sheet in 1971-1979</title>
+  </titleInfo>
+  <name usage="primary" type="personal">
+    <namePart type="given">Nanna B.</namePart>
+    <namePart type="family">Karlsson</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Dustin</namePart>
+    <namePart type="family">Schroeder</namePart>
+    <nameIdentifier typeURI="https://orcid.org" type="orcid">0000-0003-1916-3929</nameIdentifier>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Louise Sandberg</namePart>
+    <namePart type="family">Sorensen</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Winnie</namePart>
+    <namePart type="family">Chu</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Jorgen</namePart>
+    <namePart type="family">Dall</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Natalia H.</namePart>
+    <namePart type="family">Andersen</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Reese</namePart>
+    <namePart type="family">Dobson</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Emma J.</namePart>
+    <namePart type="family">Mackie</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Simon J.</namePart>
+    <namePart type="family">Kohn</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Jillian E.</namePart>
+    <namePart type="family">Steinmetz</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Angelo S.</namePart>
+    <namePart type="family">Tarzona</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Thomas</namePart>
+    <namePart type="family">Teisberg</namePart>
+    <nameIdentifier typeURI="https://orcid.org" type="orcid">0009-0000-1446-0348</nameIdentifier>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">Niels</namePart>
+    <namePart type="family">Skou</namePart>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+    </role>
+  </name>
+  <name type="corporate">
+    <namePart>Department of Glaciology and Climate, Geological Survey of Denmark and Greenland, Copenhagen, Denmark</namePart>
+    <role>
+      <roleTerm type="text">department</roleTerm>
+    </role>
+  </name>
+  <name type="corporate">
+    <namePart>Department of Geophysics, Stanford University, Stanford, CA 94305, USA</namePart>
+    <role>
+      <roleTerm type="text">department</roleTerm>
+    </role>
+  </name>
+  <name type="corporate">
+    <namePart>Department of Electrical Engineering, Stanford University, Stanford, CA 9430, USA</namePart>
+    <role>
+      <roleTerm type="text">department</roleTerm>
+    </role>
+  </name>
+  <name type="corporate">
+    <namePart>DTU Space, Technical University of Denmark, Lyngby, Denmark</namePart>
+    <role>
+      <roleTerm type="text">department</roleTerm>
+    </role>
+  </name>
+  <name type="corporate">
+    <namePart>School of Earth and Atmospheric Sciences, Georgia Institute of Technology, Atlanta, Georgia, USA</namePart>
+    <role>
+      <roleTerm type="text">department</roleTerm>
+    </role>
+  </name>
+  <name type="corporate">
+    <namePart>Department of Geological Sciences, University of Florida, Gainesville, USA</namePart>
+    <role>
+      <roleTerm type="text">department</roleTerm>
+    </role>
+  </name>
+  <name type="personal">
+    <namePart type="given">mark</namePart>
+    <namePart type="family">yoder</namePart>
+    <nameIdentifier typeURI="https://orcid.org" type="orcid">0000-0002-0083-9143</nameIdentifier>
+    <role>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/cre" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">creator</roleTerm>
+      <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/cre" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">cre</roleTerm>
+    </role>
+  </name>
+  <genre type="H2 type">Data</genre>
+  <genre type="H2 subtype">Documentation</genre>
+  <genre type="H2 subtype">Geospatial data</genre>
+  <genre type="H2 subtype">Image</genre>
+  <genre valueURI="http://id.loc.gov/authorities/genreForms/gf2018026119" authority="lcgft">Data sets</genre>
+  <genre authority="local">dataset</genre>
+  <genre valueURI="http://rdvocab.info/termList/RDAContentType/1001" authority="rdacontent">cartographic dataset</genre>
+  <typeOfResource valueURI="http://id.loc.gov/vocabulary/resourceTypes/dat" authorityURI="http://id.loc.gov/vocabulary/resourceTypes/">Dataset</typeOfResource>
+  <typeOfResource>cartographic</typeOfResource>
+  <typeOfResource>still image</typeOfResource>
+  <extension displayLabel="datacite">
+    <resourceType resourceTypeGeneral="Dataset">Documentation; Geospatial data; Image</resourceType>
+  </extension>
+  <abstract>We present an ice-penetrating radar dataset acquired over the Greenland ice sheet by aircraft during the years 1971, 1972, 1974, 1978, and 1979. The dataset comprises over 177,000 km of flight lines and contains a wealth of information on the state of the Greenland ice sheet including information on ice thickness and englacial properties. During data collection in the 1970s, the data were recorded on optical film rolls and in this manuscript, we document the digitization of these film 5 rolls and their associated geographical information. Our digitization of the data enables interaction with and analysis of the data and facilitates comparison with modern-day radar observations. The complete dataset in full resolution with associated scanned notes is available here.</abstract>
+  <note type="preferred citation">Karlsson, N., Schroeder, D., Sorensen, L., Chu, W., Dall, J., Andersen, N., Dobson, R., Mackie, E., Kohn, S., Steinmetz, J., Tarzona, A., Teisberg, T., Skou, N., Department of Glaciology and Climate, Geological Survey of Denmark and Greenland, Copenhagen, Denmark, Department of Geophysics, Stanford University, Stanford, CA 94305, USA, Department of Electrical Engineering, Stanford University, Stanford, CA 9430, USA, DTU Space, Technical University of Denmark, Lyngby, Denmark, School of Earth and Atmospheric Sciences, Georgia Institute of Technology, Atlanta, Georgia, USA, and Department of Geological Sciences, University of Florida, Gainesville, USA (2023). A Newly Digitised Ice-penetrating Radar Dataset Acquired over the Greenland Ice Sheet in 1971-1979. Stanford Digital Repository. Available at https://purl.stanford.edu/wm135gp2721. https://doi.org/10.25740/wm135gp2721.</note>
+  <subject>
+    <topic>radar film</topic>
+  </subject>
+  <subject authority="fast">
+    <topic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1086779/">Radar in earth sciences</topic>
+  </subject>
+  <subject authority="fast">
+    <geographic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1205290/">Greenland</geographic>
+  </subject>
+  <subject authority="fast">
+    <topic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/966616/">Ice sheets</topic>
+  </subject>
+  <originInfo eventType="deposit">
+    <dateIssued encoding="edtf">2023-09-14</dateIssued>
+  </originInfo>
+  <originInfo eventType="creation">
+    <dateCreated encoding="edtf">2023-08-28</dateCreated>
+  </originInfo>
+  <location>
+    <url usage="primary display">https://purl.stanford.edu/wm135gp2721</url>
+  </location>
+  <note type="contact" displayLabel="Contact">myoder96@stanford.edu</note>
+  <note type="contact" displayLabel="Contact">teisberg@stanford.edu</note>
+  <note type="contact" displayLabel="Contact">dustin.m.schroeder@stanford.edu</note>
+  <recordInfo>
+    <recordOrigin>Metadata created by user via Stanford self-deposit application</recordOrigin>
+    <recordCreationDate encoding="edtf">2023-09-14</recordCreationDate>
+  </recordInfo>
+  <relatedItem type="host">
+    <titleInfo>
+      <title>Stanford Research Data</title>
+    </titleInfo>
+    <location>
+      <url>https://purl.stanford.edu/md919gh6774</url>
+    </location>
+    <typeOfResource collection="yes"/>
+  </relatedItem>
+  <accessCondition type="useAndReproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</accessCondition>
+  <accessCondition type="license" xlink:href="https://creativecommons.org/licenses/by/4.0/legalcode">This work is licensed under a Creative Commons Attribution 4.0 International license (CC BY).</accessCondition>
+  <identifier type="doi" displayLabel="DOI">https://doi.org/10.25740/wm135gp2721</identifier>
+</mods>

--- a/spec/fixtures/document_cache/wm/135/gp/2721/public
+++ b/spec/fixtures/document_cache/wm/135/gp/2721/public
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:wm135gp2721" published="2023-09-17T08:51:19Z" publishVersion="cocina-models/0.91.0">
+  <identityMetadata>
+    <objectType>item</objectType>
+    <objectLabel>A Newly Digitised Ice-penetrating Radar Dataset Acquired over the Greenland Ice Sheet in 1971-1979</objectLabel>
+    <sourceId source="sul">hydrus:object-7070</sourceId>
+  </identityMetadata>
+  <contentMetadata objectId="druid:wm135gp2721" type="file">
+    <resource id="cocina-fileSet-wm135gp2721-dd502675-f13e-4477-90b8-c8a242b2cd69" sequence="1" type="file">
+      <file id="DTU_dropbox/DTU_1978.zip" mimetype="application/zip" size="188819522" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">a7779fffda4fdb06c294bf95edbf936cc6fcb7ca</checksum>
+        <checksum type="md5">ccd53c4fb778a45915c53a57aaa19c55</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-5f87bfea-e438-47b8-a173-bb9d789890fd" sequence="2" type="file">
+      <file id="DTU_dropbox/DTU_1979.zip" mimetype="application/zip" size="241498973" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">2cbc7d3cdde202737ae95cfa2bf4752763d32cb8</checksum>
+        <checksum type="md5">1af58c6f1a72e58706a6a224f66a8eba</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-a2d0a68e-c472-4fc4-9ce1-1b5676ef34d9" sequence="3" type="file">
+      <file id="DTU_dropbox/DTU_dropbox_1971-1972.zip" mimetype="application/zip" size="72594621" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">d7d6af5935d77f5a05815714fed6abacafd0d02a</checksum>
+        <checksum type="md5">c080757a2282da1e8698a4d88694ee41</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-d1b358b7-e351-4923-8666-3f5a488f19bd" sequence="4" type="file">
+      <file id="DTU_dropbox/DTU_Manuals.zip" mimetype="application/zip" size="15042478" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">abaf8578f6e336bd45c3b6ddb9754d2d62d58ef7</checksum>
+        <checksum type="md5">5bdf3c7103c93248c9529a3879f03fc2</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-0f5862b2-8e2a-4c57-81a5-8a4e6217c56c" sequence="5" type="file">
+      <file id="DTU_original/DTU.tar.gz" mimetype="application/gzip" size="505526461968" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">ac6c91b3c4ffd385618894da9cc526adc03b7421</checksum>
+        <checksum type="md5">60fb78d60e63df59b3f1a46b437559ce</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-cea79e27-f215-4883-ab73-5974f378df40" sequence="6" type="file">
+      <file id="DTU_original/DTU_December_2019_Scans.tar.gz" mimetype="application/gzip" size="894870831932" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">eeb97fc303d9d6d450d2c5b485a747f0ab0594a2</checksum>
+        <checksum type="md5">320d58c2ffe99298c2873600756483ee</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-74615420-8e30-4909-a1a9-f50d686b678d" sequence="7" type="file">
+      <file id="DTU_original/DTU_DMS.tar.gz" mimetype="application/gzip" size="1196585612576" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">519888688096598537725f1698ca728eb70601ce</checksum>
+        <checksum type="md5">ea8e758983cd7bafdd96806179507be4</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-07b24c14-5dd7-4ce8-b40c-62011cf9f70a" sequence="8" type="file">
+      <file id="DTU_stitched/dtu-part1-20201011-stitched.tar.gz" mimetype="application/gzip" size="254190147806" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">b4aaee6da94e00509f9190f10b761b0789cc7bcc</checksum>
+        <checksum type="md5">c3297ea9b77350af88acfac0675136e9</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-e4ad33c0-fa6f-433b-9c54-cdc5a6d7de28" sequence="9" type="file">
+      <file id="DTU_stitched/dtu-part2-20201115-stitched.tar.gz" mimetype="application/gzip" size="437432722389" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">e0fd28659716723e9b51aa2338f82fb5d4cecb3e</checksum>
+        <checksum type="md5">4a8bd988bce4086d92196f430dd6c28d</checksum>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-wm135gp2721-710f74d9-24f9-4df4-8704-f3beef6a717f" sequence="10" type="file">
+      <file id="DTU_stitched/DTU_DMS.tar.gz" mimetype="application/gzip" size="520308721286" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">8733e53c45740e8947a898f28ae690c4cff1cbeb</checksum>
+        <checksum type="md5">824cd8689a7455175e39b3245382a35a</checksum>
+      </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</human>
+      <license>https://creativecommons.org/licenses/by/4.0/legalcode</license>
+    </use>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:wm135gp2721">
+      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:md919gh6774"/>
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>A Newly Digitised Ice-penetrating Radar Dataset Acquired over the Greenland Ice Sheet in 1971-1979</dc:title>
+    <dc:contributor>Karlsson, Nanna B. (authoraut)</dc:contributor>
+    <dc:contributor>Schroeder, Dustin (authoraut)</dc:contributor>
+    <dc:contributor>Sorensen, Louise Sandberg (authoraut)</dc:contributor>
+    <dc:contributor>Chu, Winnie (authoraut)</dc:contributor>
+    <dc:contributor>Dall, Jorgen (authoraut)</dc:contributor>
+    <dc:contributor>Andersen, Natalia H. (authoraut)</dc:contributor>
+    <dc:contributor>Dobson, Reese (authoraut)</dc:contributor>
+    <dc:contributor>Mackie, Emma J. (authoraut)</dc:contributor>
+    <dc:contributor>Kohn, Simon J. (authoraut)</dc:contributor>
+    <dc:contributor>Steinmetz, Jillian E. (authoraut)</dc:contributor>
+    <dc:contributor>Tarzona, Angelo S. (authoraut)</dc:contributor>
+    <dc:contributor>Teisberg, Thomas (authoraut)</dc:contributor>
+    <dc:contributor>Skou, Niels (authoraut)</dc:contributor>
+    <dc:contributor>Department of Glaciology and Climate, Geological Survey of Denmark and Greenland, Copenhagen, Denmark (department)</dc:contributor>
+    <dc:contributor>Department of Geophysics, Stanford University, Stanford, CA 94305, USA (department)</dc:contributor>
+    <dc:contributor>Department of Electrical Engineering, Stanford University, Stanford, CA 9430, USA (department)</dc:contributor>
+    <dc:contributor>DTU Space, Technical University of Denmark, Lyngby, Denmark (department)</dc:contributor>
+    <dc:contributor>School of Earth and Atmospheric Sciences, Georgia Institute of Technology, Atlanta, Georgia, USA (department)</dc:contributor>
+    <dc:contributor>Department of Geological Sciences, University of Florida, Gainesville, USA (department)</dc:contributor>
+    <dc:creator>yoder, mark</dc:creator>
+    <dc:type>Data</dc:type>
+    <dc:type>Documentation</dc:type>
+    <dc:type>Geospatial data</dc:type>
+    <dc:type>Image</dc:type>
+    <dc:type>Data sets</dc:type>
+    <dc:type>dataset</dc:type>
+    <dc:type>cartographic dataset</dc:type>
+    <dc:type>StillImage</dc:type>
+    <dc:description>We present an ice-penetrating radar dataset acquired over the Greenland ice sheet by aircraft during the years 1971, 1972, 1974, 1978, and 1979. The dataset comprises over 177,000 km of flight lines and contains a wealth of information on the state of the Greenland ice sheet including information on ice thickness and englacial properties. During data collection in the 1970s, the data were recorded on optical film rolls and in this manuscript, we document the digitization of these film 5 rolls and their associated geographical information. Our digitization of the data enables interaction with and analysis of the data and facilitates comparison with modern-day radar observations. The complete dataset in full resolution with associated scanned notes is available here.</dc:description>
+    <dc:description type="preferred citation">Karlsson, N., Schroeder, D., Sorensen, L., Chu, W., Dall, J., Andersen, N., Dobson, R., Mackie, E., Kohn, S., Steinmetz, J., Tarzona, A., Teisberg, T., Skou, N., Department of Glaciology and Climate, Geological Survey of Denmark and Greenland, Copenhagen, Denmark, Department of Geophysics, Stanford University, Stanford, CA 94305, USA, Department of Electrical Engineering, Stanford University, Stanford, CA 9430, USA, DTU Space, Technical University of Denmark, Lyngby, Denmark, School of Earth and Atmospheric Sciences, Georgia Institute of Technology, Atlanta, Georgia, USA, and Department of Geological Sciences, University of Florida, Gainesville, USA (2023). A Newly Digitised Ice-penetrating Radar Dataset Acquired over the Greenland Ice Sheet in 1971-1979. Stanford Digital Repository. Available at https://purl.stanford.edu/wm135gp2721. https://doi.org/10.25740/wm135gp2721.</dc:description>
+    <dc:subject>radar film</dc:subject>
+    <dc:subject>Radar in earth sciences</dc:subject>
+    <dc:subject/>
+    <dc:coverage>Greenland</dc:coverage>
+    <dc:subject>Ice sheets</dc:subject>
+    <dc:date>2023-09-14</dc:date>
+    <dc:date>2023-08-28</dc:date>
+    <dc:identifier>https://purl.stanford.edu/wm135gp2721</dc:identifier>
+    <dc:description type="contact" displayLabel="Contact">myoder96@stanford.edu</dc:description>
+    <dc:description type="contact" displayLabel="Contact">teisberg@stanford.edu</dc:description>
+    <dc:description type="contact" displayLabel="Contact">dustin.m.schroeder@stanford.edu</dc:description>
+    <dc:relation type="collection">Stanford Research Data</dc:relation>
+    <dc:identifier>doi: https://doi.org/10.25740/wm135gp2721</dc:identifier>
+  </oai_dc:dc>
+  <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+    <titleInfo>
+      <title>A Newly Digitised Ice-penetrating Radar Dataset Acquired over the Greenland Ice Sheet in 1971-1979</title>
+    </titleInfo>
+    <name usage="primary" type="personal">
+      <namePart type="given">Nanna B.</namePart>
+      <namePart type="family">Karlsson</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Dustin</namePart>
+      <namePart type="family">Schroeder</namePart>
+      <nameIdentifier typeURI="https://orcid.org" type="orcid">0000-0003-1916-3929</nameIdentifier>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Louise Sandberg</namePart>
+      <namePart type="family">Sorensen</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Winnie</namePart>
+      <namePart type="family">Chu</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Jorgen</namePart>
+      <namePart type="family">Dall</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Natalia H.</namePart>
+      <namePart type="family">Andersen</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Reese</namePart>
+      <namePart type="family">Dobson</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Emma J.</namePart>
+      <namePart type="family">Mackie</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Simon J.</namePart>
+      <namePart type="family">Kohn</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Jillian E.</namePart>
+      <namePart type="family">Steinmetz</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Angelo S.</namePart>
+      <namePart type="family">Tarzona</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Thomas</namePart>
+      <namePart type="family">Teisberg</namePart>
+      <nameIdentifier typeURI="https://orcid.org" type="orcid">0009-0000-1446-0348</nameIdentifier>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Niels</namePart>
+      <namePart type="family">Skou</namePart>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">author</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/aut" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">aut</roleTerm>
+      </role>
+    </name>
+    <name type="corporate">
+      <namePart>Department of Glaciology and Climate, Geological Survey of Denmark and Greenland, Copenhagen, Denmark</namePart>
+      <role>
+        <roleTerm type="text">department</roleTerm>
+      </role>
+    </name>
+    <name type="corporate">
+      <namePart>Department of Geophysics, Stanford University, Stanford, CA 94305, USA</namePart>
+      <role>
+        <roleTerm type="text">department</roleTerm>
+      </role>
+    </name>
+    <name type="corporate">
+      <namePart>Department of Electrical Engineering, Stanford University, Stanford, CA 9430, USA</namePart>
+      <role>
+        <roleTerm type="text">department</roleTerm>
+      </role>
+    </name>
+    <name type="corporate">
+      <namePart>DTU Space, Technical University of Denmark, Lyngby, Denmark</namePart>
+      <role>
+        <roleTerm type="text">department</roleTerm>
+      </role>
+    </name>
+    <name type="corporate">
+      <namePart>School of Earth and Atmospheric Sciences, Georgia Institute of Technology, Atlanta, Georgia, USA</namePart>
+      <role>
+        <roleTerm type="text">department</roleTerm>
+      </role>
+    </name>
+    <name type="corporate">
+      <namePart>Department of Geological Sciences, University of Florida, Gainesville, USA</namePart>
+      <role>
+        <roleTerm type="text">department</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">mark</namePart>
+      <namePart type="family">yoder</namePart>
+      <nameIdentifier typeURI="https://orcid.org" type="orcid">0000-0002-0083-9143</nameIdentifier>
+      <role>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/cre" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="text">creator</roleTerm>
+        <roleTerm valueURI="http://id.loc.gov/vocabulary/relators/cre" authority="marcrelator" authorityURI="http://id.loc.gov/vocabulary/relators/" type="code">cre</roleTerm>
+      </role>
+    </name>
+    <genre type="H2 type">Data</genre>
+    <genre type="H2 subtype">Documentation</genre>
+    <genre type="H2 subtype">Geospatial data</genre>
+    <genre type="H2 subtype">Image</genre>
+    <genre valueURI="http://id.loc.gov/authorities/genreForms/gf2018026119" authority="lcgft">Data sets</genre>
+    <genre authority="local">dataset</genre>
+    <genre valueURI="http://rdvocab.info/termList/RDAContentType/1001" authority="rdacontent">cartographic dataset</genre>
+    <typeOfResource valueURI="http://id.loc.gov/vocabulary/resourceTypes/dat" authorityURI="http://id.loc.gov/vocabulary/resourceTypes/">Dataset</typeOfResource>
+    <typeOfResource>cartographic</typeOfResource>
+    <typeOfResource>still image</typeOfResource>
+    <extension displayLabel="datacite">
+      <resourceType resourceTypeGeneral="Dataset">Documentation; Geospatial data; Image</resourceType>
+    </extension>
+    <abstract>We present an ice-penetrating radar dataset acquired over the Greenland ice sheet by aircraft during the years 1971, 1972, 1974, 1978, and 1979. The dataset comprises over 177,000 km of flight lines and contains a wealth of information on the state of the Greenland ice sheet including information on ice thickness and englacial properties. During data collection in the 1970s, the data were recorded on optical film rolls and in this manuscript, we document the digitization of these film 5 rolls and their associated geographical information. Our digitization of the data enables interaction with and analysis of the data and facilitates comparison with modern-day radar observations. The complete dataset in full resolution with associated scanned notes is available here.</abstract>
+    <note type="preferred citation">Karlsson, N., Schroeder, D., Sorensen, L., Chu, W., Dall, J., Andersen, N., Dobson, R., Mackie, E., Kohn, S., Steinmetz, J., Tarzona, A., Teisberg, T., Skou, N., Department of Glaciology and Climate, Geological Survey of Denmark and Greenland, Copenhagen, Denmark, Department of Geophysics, Stanford University, Stanford, CA 94305, USA, Department of Electrical Engineering, Stanford University, Stanford, CA 9430, USA, DTU Space, Technical University of Denmark, Lyngby, Denmark, School of Earth and Atmospheric Sciences, Georgia Institute of Technology, Atlanta, Georgia, USA, and Department of Geological Sciences, University of Florida, Gainesville, USA (2023). A Newly Digitised Ice-penetrating Radar Dataset Acquired over the Greenland Ice Sheet in 1971-1979. Stanford Digital Repository. Available at https://purl.stanford.edu/wm135gp2721. https://doi.org/10.25740/wm135gp2721.</note>
+    <subject>
+      <topic>radar film</topic>
+    </subject>
+    <subject authority="fast">
+      <topic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1086779/">Radar in earth sciences</topic>
+    </subject>
+    <subject authority="fast">
+      <geographic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/1205290/">Greenland</geographic>
+    </subject>
+    <subject authority="fast">
+      <topic authority="fast" authorityURI="http://id.worldcat.org/fast/" valueURI="http://id.worldcat.org/fast/966616/">Ice sheets</topic>
+    </subject>
+    <originInfo eventType="deposit">
+      <dateIssued encoding="edtf">2023-09-14</dateIssued>
+    </originInfo>
+    <originInfo eventType="creation">
+      <dateCreated encoding="edtf">2023-08-28</dateCreated>
+    </originInfo>
+    <location>
+      <url usage="primary display">https://purl.stanford.edu/wm135gp2721</url>
+    </location>
+    <note type="contact" displayLabel="Contact">myoder96@stanford.edu</note>
+    <note type="contact" displayLabel="Contact">teisberg@stanford.edu</note>
+    <note type="contact" displayLabel="Contact">dustin.m.schroeder@stanford.edu</note>
+    <recordInfo>
+      <recordOrigin>Metadata created by user via Stanford self-deposit application</recordOrigin>
+      <recordCreationDate encoding="edtf">2023-09-14</recordCreationDate>
+    </recordInfo>
+    <relatedItem type="host">
+      <titleInfo>
+        <title>Stanford Research Data</title>
+      </titleInfo>
+      <location>
+        <url>https://purl.stanford.edu/md919gh6774</url>
+      </location>
+      <typeOfResource collection="yes"/>
+    </relatedItem>
+    <accessCondition type="useAndReproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</accessCondition>
+    <accessCondition type="license" xlink:href="https://creativecommons.org/licenses/by/4.0/legalcode">This work is licensed under a Creative Commons Attribution 4.0 International license (CC BY).</accessCondition>
+    <identifier type="doi" displayLabel="DOI">https://doi.org/10.25740/wm135gp2721</identifier>
+  </mods>
+  <releaseData>
+    <release to="Searchworks">true</release>
+  </releaseData>
+</publicObject>


### PR DESCRIPTION
## WHY?

Closes #717

The PR adds ORCID to the purl page, for those contributors that have orcid ids.

Assumption:  only `ModsDisplay::Name::Person` can have an ORCID.

This work also required updates to the following gems:  mods, stanford-mods (barely), and mods_display.  As you may know, this work spawned ticket sul-dlss/mods/issues/58 wondering if cocina -> MODS conversion might use any other MODS features that didn't exist in MODS 3.4.

**Question:  Is the html good accessibility practice?**

Here's what the html looks like:
```
<dl>
  <dt>blah</dt>
  <dd>
            <span>Teisberg, Thomas</span>
              <span class="orcid">
                <a href="https://orcid.org/0009-0000-1446-0348" aria-label="view ORCID page for author Teisberg, Thomas">
                  <img alt="ORCiD icon" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16">
                  https://orcid.org/0009-0000-1446-0348
                </a> (unverified)</span>
  </dd>
```


## BEFORE

<img width="754" alt="image" src="https://github.com/sul-dlss/purl/assets/96775/03cef45e-8656-4e7b-a78d-c552ffea85ae">

## AFTER

<img width="772" alt="image" src="https://github.com/sul-dlss/purl/assets/96775/586edfc1-2611-493f-b16f-65b9fe9614c9">
