### PR TITLE
Adjust heading order.

### DIFF
--- a/app/views/purl/index.html.erb
+++ b/app/views/purl/index.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-8">
-    <h2>About Persistent URLs (PURLs)</h2>
+    <h1 class="h2">About Persistent URLs (PURLs)</h1>
 
     <p>
       The Stanford Digital Repository supports management of scholarly information resources of enduring value to Stanford University. Faculty, students, and researchers use SDR services to promote and protect the products of their work. Scholars around the world use content in the SDR in their research. The benefits of this service distinguish the SDR from other content storage or management options on campus: deposited content is preserved in a robust, reliable, and secure environment for access by scholars today and for generations to come.
@@ -13,7 +13,7 @@
   <div class="col-md-4">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title">More Information</h3>
+        <h2 class="h3 panel-title">More Information</h2>
       </div>
       <div class="panel-body">
         <ul class="list-unstyled">


### PR DESCRIPTION
closes #755

The easiest possible way to do this is change the html heading tag but add the bootstrap heading class, e.g., `<h2>About Persistent URLs (PURLs)</h2>` --> `<h1 class="h2">About Persistent URLs (PURLs)</h1>`. However, this means that some of the `<h1>` properties are picked up, changing the layout slightly.

Before:
![image](https://github.com/sul-dlss/purl/assets/588335/f69d4513-e943-4eac-bc0e-bee5d40ca508)

After:
![image](https://github.com/sul-dlss/purl/assets/588335/628b0374-cd6b-4b7d-8633-2f79e23849aa)

Fixing this would require some CSS shenanigans. Considering this is a landing page that no one actually lands on (I believe), I'd suggest that it isn't worth extra CSS complexity.

@dbranchini Is this acceptable?