### PR TITLE
Remove popper js from importmap.rb

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,7 +3,6 @@
 pin "application", preload: true
 pin "jquery", to: "https://ga.jspm.io/npm:jquery@3.6.1/dist/jquery.js"
 pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.2.3/dist/js/bootstrap.esm.js"
-pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/lib/index.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
To the best I can tell it isn't used.