### PR TITLE
Only link released collections to SW

### DIFF
--- a/app/views/purl/_collection.html.erb
+++ b/app/views/purl/_collection.html.erb
@@ -6,7 +6,7 @@
     <div class="section-body">
       <% document.containing_purl_collections.each do |collection_document| %>
         <p class="mb-2"><%= collection_document.title %></p>
-        <% if collection_document.folio_instance_hrid %>
+        <% if collection_document.folio_instance_hrid && collection_document.released_to?('Searchworks') %>
           <%= link_to('View other items in this collection in SearchWorks', "#{Settings.searchworks.url}/catalog?f[collection][]=#{collection_document.folio_instance_hrid}") %>
         <% end %>
       <% end %>

--- a/app/views/purl/_collection_items.html.erb
+++ b/app/views/purl/_collection_items.html.erb
@@ -1,4 +1,4 @@
-<% if document.collection? && document.folio_instance_hrid %>
+<% if document.collection? && document.folio_instance_hrid && document.released_to?('Searchworks') %>
   <div class="section">
     <div class="section-heading">
       <h2>Items in collection</h2>

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -106,6 +106,14 @@ RSpec.describe 'Integration Scenarios' do
     end
   end
 
+  context 'item that is part of collection not released to searchworks' do
+    it 'lists the collection name and does not link to items in collection' do
+      visit '/cd027gx5097'
+      expect(page).to have_content 'Edward Flanders Ricketts papers, 1936-1979 (inclusive), 1936-1947 (bulk)'
+      expect(page).not_to have_link 'View other items in this collection in SearchWorks'
+    end
+  end
+
   context 'cabinet minutes' do
     it 'works' do
       visit '/gx074xz5520'

--- a/spec/fixtures/document_cache/cd/027/gx/5097/mods
+++ b/spec/fixtures/document_cache/cd/027/gx/5097/mods
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+  <titleInfo>
+    <title>Collecting Reports : May, 1937</title>
+  </titleInfo>
+  <location>
+    <url usage="primary display">https://purl.stanford.edu/cd027gx5097</url>
+  </location>
+  <relatedItem type="host">
+    <titleInfo>
+      <title>Edward Flanders Ricketts papers, 1936-1979 (inclusive), 1936-1947 (bulk)</title>
+    </titleInfo>
+    <location>
+      <url>https://purl.stanford.edu/ss099gb5528</url>
+    </location>
+    <typeOfResource collection="yes"/>
+  </relatedItem>
+  <accessCondition type="useAndReproduction">While Special Collections is the owner of the physical and digital items, permission to examine collection materials is not an authorization to publish. These materials are made available for use in research, teaching, and private study. Any transmission or reproduction beyond that allowed by fair use requires permission from the owners of rights, heir(s) or assigns. See: http://library.stanford.edu/spc/using-collections/permission-publish</accessCondition>
+  <accessCondition type="copyright">Materials may be subject to copyright.</accessCondition>
+</mods>

--- a/spec/fixtures/document_cache/cd/027/gx/5097/public
+++ b/spec/fixtures/document_cache/cd/027/gx/5097/public
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:cd027gx5097" published="2023-04-19T03:00:16Z" publishVersion="cocina-models/0.90.0">
+  <identityMetadata>
+    <objectType>item</objectType>
+    <objectLabel>Collecting Reports : May, 1937</objectLabel>
+    <sourceId source="sul">sul:B12_F17_reports</sourceId>
+  </identityMetadata>
+  <contentMetadata objectId="druid:cd027gx5097" type="book">
+    <bookData readingOrder="ltr"/>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_1" sequence="1" type="page">
+      <label>Page 1</label>
+      <file id="cd027gx5097_0001.pdf" mimetype="application/pdf" size="1286732" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">ec5319fa0c49d3d8f50bb9c43a5ccdbc78d1decd</checksum>
+        <checksum type="md5">b88eeaa23f4644910d646259ce9c9817</checksum>
+      </file>
+      <file id="cd027gx5097_0001.xml" mimetype="application/xml" size="74861" publish="yes" shelve="yes" preserve="yes" role="transcription">
+        <checksum type="sha1">959fe418e26d271a52f2133518b34c01cad4921f</checksum>
+        <checksum type="md5">da80f0e0212caf85b5a76c9ef99a9222</checksum>
+      </file>
+      <file id="cd027gx5097_0001.jp2" mimetype="image/jp2" size="6846524" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">f8aad04c25e3d3b91da528d3dbf657bc4fc3dd09</checksum>
+        <checksum type="md5">085085625c40c3a33facf1aa2d90b805</checksum>
+        <imageData height="6806" width="5339"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_2" sequence="2" type="page">
+      <label>Page 2</label>
+      <file id="cd027gx5097_0002.pdf" mimetype="application/pdf" size="1471858" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">df69953b4e4d379119b2d67250f354fd3d99d160</checksum>
+        <checksum type="md5">e3e4f40fcedcc6879dd45f5cf6d41b9b</checksum>
+      </file>
+      <file id="cd027gx5097_0002.xml" mimetype="application/xml" size="81024" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">97fc670207afb379701e37078c1cef252e061d34</checksum>
+        <checksum type="md5">c8db3725a836a019a9d675c4379f60f1</checksum>
+      </file>
+      <file id="cd027gx5097_0002.jp2" mimetype="image/jp2" size="6866977" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">ec79c4dc187da310d52c3c834f8111def3dcc1d6</checksum>
+        <checksum type="md5">96c5e7b56027946158c9cbe9c497adcf</checksum>
+        <imageData height="6833" width="5334"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_3" sequence="3" type="page">
+      <label>Page 3</label>
+      <file id="cd027gx5097_0003.pdf" mimetype="application/pdf" size="1649636" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">9bbe3897a415fd0ccb3f3ec62f70a723ac9fb056</checksum>
+        <checksum type="md5">3cb50a50e7ce37fff8bed98136e3e8d1</checksum>
+      </file>
+      <file id="cd027gx5097_0003.xml" mimetype="application/xml" size="118939" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">04a8180febf9bfe128e46675c8ebdc0fc5c0fd0e</checksum>
+        <checksum type="md5">569778b903210c1bf03eab3ee28f92b6</checksum>
+      </file>
+      <file id="cd027gx5097_0003.jp2" mimetype="image/jp2" size="6920060" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">ad8bd26d6d295c2a47a3af90cb9fa26c09b3a95c</checksum>
+        <checksum type="md5">b71d7180f4b0ef99501a9117d2c9c022</checksum>
+        <imageData height="6824" width="5382"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_4" sequence="4" type="page">
+      <label>Page 4</label>
+      <file id="cd027gx5097_0004.pdf" mimetype="application/pdf" size="1469511" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">22710d1164d26036c5bc7a3e2779aec29dbd15c0</checksum>
+        <checksum type="md5">0a870314edbd029b5a6d3b605e2ac9cc</checksum>
+      </file>
+      <file id="cd027gx5097_0004.xml" mimetype="application/xml" size="69903" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">34474faebcf3bb2b8bc31cc8843f630a29425938</checksum>
+        <checksum type="md5">dcae870c88da4f31bd0046686a8b5248</checksum>
+      </file>
+      <file id="cd027gx5097_0004.jp2" mimetype="image/jp2" size="6926304" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">4f40644df5acb121e18b5402f55b62fd246f0b33</checksum>
+        <checksum type="md5">2b9af6cf215858cc17de8e680aba9988</checksum>
+        <imageData height="6877" width="5365"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_5" sequence="5" type="page">
+      <label>Page 5</label>
+      <file id="cd027gx5097_0005.pdf" mimetype="application/pdf" size="1381765" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">10a413116e487ef165a7b6b2039c131c9febdafb</checksum>
+        <checksum type="md5">08efc98195bf9ee028271291319f908b</checksum>
+      </file>
+      <file id="cd027gx5097_0005.xml" mimetype="application/xml" size="86129" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">239173f6fa24e3cf60a25f81b97cab92698d5c71</checksum>
+        <checksum type="md5">25bc5abec826548af03542aca74d9b48</checksum>
+      </file>
+      <file id="cd027gx5097_0005.jp2" mimetype="image/jp2" size="6951958" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">4a63a1d7b63b52cd3b75f120bfce54e350d216e9</checksum>
+        <checksum type="md5">ae78bef562c22eb568768a31d5bf68a7</checksum>
+        <imageData height="6882" width="5382"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_6" sequence="6" type="page">
+      <label>Page 6</label>
+      <file id="cd027gx5097_0006.pdf" mimetype="application/pdf" size="1371672" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">ad0bb4f5ebd36ffe7103f2b9fd9f06848bbd714e</checksum>
+        <checksum type="md5">6371e1e65e452119a70d1404a68c3ff2</checksum>
+      </file>
+      <file id="cd027gx5097_0006.xml" mimetype="application/xml" size="103279" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">4865a31dd1b61bfb16e05788fe671dc5c5dbc3fd</checksum>
+        <checksum type="md5">29d0f9c0b26ce8b93e8cd1e0ba363845</checksum>
+      </file>
+      <file id="cd027gx5097_0006.jp2" mimetype="image/jp2" size="6998281" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">c720583a6a108ec8f10400332fd80c96617c17d4</checksum>
+        <checksum type="md5">5e65c114a7910f3b3acb2b2df1806f2c</checksum>
+        <imageData height="6880" width="5400"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_7" sequence="7" type="page">
+      <label>Page 7</label>
+      <file id="cd027gx5097_0007.pdf" mimetype="application/pdf" size="1423824" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">df9e3403c1bfff50df451a730393e5f716ef2b47</checksum>
+        <checksum type="md5">61e0ab9727e14415f7236328ec5088dd</checksum>
+      </file>
+      <file id="cd027gx5097_0007.xml" mimetype="application/xml" size="67796" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">25231afcdb60d3e5571a7d70100168addc8987f4</checksum>
+        <checksum type="md5">a840454685cd15128ee9ac850cdf283c</checksum>
+      </file>
+      <file id="cd027gx5097_0007.jp2" mimetype="image/jp2" size="6921615" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">746bd8b77c2ad9cdd4a74ba72604dfc792109acc</checksum>
+        <checksum type="md5">216d8f80baa7082ab0d2bff716f01d9e</checksum>
+        <imageData height="6864" width="5353"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_8" sequence="8" type="page">
+      <label>Page 8</label>
+      <file id="cd027gx5097_0008.pdf" mimetype="application/pdf" size="1399483" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">bebbdb28c36c87112aa15f266664a732f55b3b32</checksum>
+        <checksum type="md5">bcb9268355570110012c5b156e5800ba</checksum>
+      </file>
+      <file id="cd027gx5097_0008.xml" mimetype="application/xml" size="98719" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">acf91b75e56260eb111996ef7d670f4cedb75c48</checksum>
+        <checksum type="md5">f2137818d1c4a12bdd5efb791a0723f8</checksum>
+      </file>
+      <file id="cd027gx5097_0008.jp2" mimetype="image/jp2" size="7037511" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">68744887b2043e8348394b83e44c5b69466d22df</checksum>
+        <checksum type="md5">92fcda2acf55df5149e522b0b835a377</checksum>
+        <imageData height="6898" width="5430"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_9" sequence="9" type="page">
+      <label>Page 9</label>
+      <file id="cd027gx5097_0009.pdf" mimetype="application/pdf" size="1463631" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">2c8d371e48e64884abe9d534f106d14321611a50</checksum>
+        <checksum type="md5">bb9550d71ac7cf4bd3ff7ce4785155b6</checksum>
+      </file>
+      <file id="cd027gx5097_0009.xml" mimetype="application/xml" size="85222" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">013a2fac01e044794c8614d2050464451bde2d55</checksum>
+        <checksum type="md5">f07e04778e294a15ef3f436e06974485</checksum>
+      </file>
+      <file id="cd027gx5097_0009.jp2" mimetype="image/jp2" size="7035803" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">e9016bbdf278091308af4f89229926401e11e0c2</checksum>
+        <checksum type="md5">8080ec9f81e74f9c7dc616520944d21c</checksum>
+        <imageData height="6911" width="5437"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_10" sequence="10" type="page">
+      <label>Page 10</label>
+      <file id="cd027gx5097_0010.pdf" mimetype="application/pdf" size="1385812" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">5591c5182a977362bb1c638c1db71abcc6d23e55</checksum>
+        <checksum type="md5">4578f5090759c75266baebfa1341c8ba</checksum>
+      </file>
+      <file id="cd027gx5097_0010.xml" mimetype="application/xml" size="61764" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">86c365d0064f9e6cb0f50241bba959a4f3f30e7b</checksum>
+        <checksum type="md5">77fd45e9d2f00d60be2c3ece6ff82962</checksum>
+      </file>
+      <file id="cd027gx5097_0010.jp2" mimetype="image/jp2" size="6851011" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">5230bf9a7c73f154c20f57a131d5aa54e1fc560a</checksum>
+        <checksum type="md5">08d605cbcf5f2e2f6241ebdfe9e213e4</checksum>
+        <imageData height="6816" width="5340"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_11" sequence="11" type="page">
+      <label>Page 11</label>
+      <file id="cd027gx5097_0011.pdf" mimetype="application/pdf" size="914329" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">a0fb4dfe73535a71939f625874fb65ff8066748b</checksum>
+        <checksum type="md5">6720aae5bba978ba0d792253416a3117</checksum>
+      </file>
+      <file id="cd027gx5097_0011.xml" mimetype="application/xml" size="23810" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">2710ff8921588d5585c3e241dd662c0435a7bfd1</checksum>
+        <checksum type="md5">1c01655e37bfc260143afcf7abd95a72</checksum>
+      </file>
+      <file id="cd027gx5097_0011.jp2" mimetype="image/jp2" size="6993840" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">2276774f53704fb4bf55061b7689741c6147b775</checksum>
+        <checksum type="md5">6b5e88c15c2f859104138b0c87f16813</checksum>
+        <imageData height="6854" width="5416"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_12" sequence="12" type="page">
+      <label>Page 12</label>
+      <file id="cd027gx5097_0012.pdf" mimetype="application/pdf" size="831661" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">96c6d425c5ed3aaa5b138b352a816c3e5dd231b8</checksum>
+        <checksum type="md5">5f5a802e7e812ca53de959fb02735efc</checksum>
+      </file>
+      <file id="cd027gx5097_0012.xml" mimetype="application/xml" size="14584" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">7410d7fddefb377de70214d7b097ac903db7b654</checksum>
+        <checksum type="md5">b0ce44806cd218e2ec84011ed3872904</checksum>
+      </file>
+      <file id="cd027gx5097_0012.jp2" mimetype="image/jp2" size="6967094" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">a1d8439075becea8a80b6e17f33173855a0090f8</checksum>
+        <checksum type="md5">7076f138db0b5bc872bc66c8f88dca1a</checksum>
+        <imageData height="6880" width="5383"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_13" sequence="13" type="page">
+      <label>Page 13</label>
+      <file id="cd027gx5097_0013.pdf" mimetype="application/pdf" size="856127" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">947b189606c736cebf7488c744deeaa8b2b9c273</checksum>
+        <checksum type="md5">aed87552c60341bf47551d7de355a8e3</checksum>
+      </file>
+      <file id="cd027gx5097_0013.xml" mimetype="application/xml" size="21417" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">eb5b712371da2a453f7c7a318a5a74f96714f94a</checksum>
+        <checksum type="md5">a9df8054909b97d086aa189e79129364</checksum>
+      </file>
+      <file id="cd027gx5097_0013.jp2" mimetype="image/jp2" size="6958207" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">ac3e1ef35659d087cd697313250bb737e3f002a2</checksum>
+        <checksum type="md5">e8fd75ccabaf8438d577f889fa30ad03</checksum>
+        <imageData height="6883" width="5366"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_14" sequence="14" type="page">
+      <label>Page 14</label>
+      <file id="cd027gx5097_0014.pdf" mimetype="application/pdf" size="998445" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">252b5dc7cd61932837df45d8459a4bec5ab05420</checksum>
+        <checksum type="md5">8ea0b639e02167e0f602229d13705fed</checksum>
+      </file>
+      <file id="cd027gx5097_0014.xml" mimetype="application/xml" size="24632" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">010fa06854c9cfa790a80dddfa98b198ab2211e5</checksum>
+        <checksum type="md5">7967adb877a611790c2311b9cda71e45</checksum>
+      </file>
+      <file id="cd027gx5097_0014.jp2" mimetype="image/jp2" size="7009202" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">78b88263a1c119c1aa984ff6a805fa1d166b89f1</checksum>
+        <checksum type="md5">e8b07504328cc88f63461ddcc8470385</checksum>
+        <imageData height="6874" width="5412"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_15" sequence="15" type="page">
+      <label>Page 15</label>
+      <file id="cd027gx5097_0015.pdf" mimetype="application/pdf" size="778312" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">64659a7aae95b1920cf594fb513f9db726038a03</checksum>
+        <checksum type="md5">bf6329c57ea4cf36c78be86a39c2038a</checksum>
+      </file>
+      <file id="cd027gx5097_0015.xml" mimetype="application/xml" size="14315" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">4ed3fcdd1fd7dab85393fbaca3acffdb23c68210</checksum>
+        <checksum type="md5">7dadb13bdf54df64d18a7b06c8c5858b</checksum>
+      </file>
+      <file id="cd027gx5097_0015.jp2" mimetype="image/jp2" size="6964352" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">48e21846293e9e40006ec3a4a82a3c66fd378303</checksum>
+        <checksum type="md5">0f850eff0e93acbc80db588d3645f762</checksum>
+        <imageData height="6854" width="5399"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_16" sequence="16" type="page">
+      <label>Page 16</label>
+      <file id="cd027gx5097_0016.pdf" mimetype="application/pdf" size="782135" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">a38f6d615a494336cccf96e707032946a995f494</checksum>
+        <checksum type="md5">b6c729ee6a97dd827c64bf67ce295c17</checksum>
+      </file>
+      <file id="cd027gx5097_0016.xml" mimetype="application/xml" size="11700" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">5f25ef56311b46e03000023574c5f8cbbdf8ca54</checksum>
+        <checksum type="md5">7a907bbb6899988fcf02f70f8fa514e3</checksum>
+      </file>
+      <file id="cd027gx5097_0016.jp2" mimetype="image/jp2" size="7002814" publish="yes" shelve="yes" preserve="no">
+        <checksum type="sha1">c7b5de30c8ad6331bfca9c40113a0f3d9e44ae3b</checksum>
+        <checksum type="md5">5524d7ae7f41c65fd7de86228c02dda1</checksum>
+        <imageData height="6903" width="5387"/>
+      </file>
+    </resource>
+    <resource id="cocina-fileSet-cd027gx5097-cd027gx5097_17" sequence="17" type="object">
+      <label>Object 1</label>
+      <file id="cd027gx5097.pdf" mimetype="application/pdf" size="19575569" publish="yes" shelve="yes" preserve="yes">
+        <checksum type="sha1">70e41d5d66196250118078c0d6df121635f8387f</checksum>
+        <checksum type="md5">f6e878dbbd05c79c18ba30a484af1266</checksum>
+      </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">While Special Collections is the owner of the physical and digital items, permission to examine collection materials is not an authorization to publish. These materials are made available for use in research, teaching, and private study. Any transmission or reproduction beyond that allowed by fair use requires permission from the owners of rights, heir(s) or assigns. See: http://library.stanford.edu/spc/using-collections/permission-publish</human>
+      <license/>
+    </use>
+    <copyright>
+      <human>Materials may be subject to copyright.</human>
+    </copyright>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:cd027gx5097">
+      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:ss099gb5528"/>
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Collecting Reports : May, 1937</dc:title>
+    <dc:identifier>https://purl.stanford.edu/cd027gx5097</dc:identifier>
+    <dc:relation type="collection">Edward Flanders Ricketts papers, 1936-1979 (inclusive), 1936-1947 (bulk)</dc:relation>
+  </oai_dc:dc>
+  <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+    <titleInfo>
+      <title>Collecting Reports : May, 1937</title>
+    </titleInfo>
+    <location>
+      <url usage="primary display">https://purl.stanford.edu/cd027gx5097</url>
+    </location>
+    <relatedItem type="host">
+      <titleInfo>
+        <title>Edward Flanders Ricketts papers, 1936-1979 (inclusive), 1936-1947 (bulk)</title>
+      </titleInfo>
+      <location>
+        <url>https://purl.stanford.edu/ss099gb5528</url>
+      </location>
+      <typeOfResource collection="yes"/>
+    </relatedItem>
+    <accessCondition type="useAndReproduction">While Special Collections is the owner of the physical and digital items, permission to examine collection materials is not an authorization to publish. These materials are made available for use in research, teaching, and private study. Any transmission or reproduction beyond that allowed by fair use requires permission from the owners of rights, heir(s) or assigns. See: http://library.stanford.edu/spc/using-collections/permission-publish</accessCondition>
+    <accessCondition type="copyright">Materials may be subject to copyright.</accessCondition>
+  </mods>
+  <thumb>cd027gx5097/cd027gx5097_0001.jp2</thumb>
+</publicObject>

--- a/spec/fixtures/document_cache/ss/099/gb/5528/mods
+++ b/spec/fixtures/document_cache/ss/099/gb/5528/mods
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+  <titleInfo>
+    <title>Edward Flanders Ricketts papers, 1936-1979 (inclusive), 1936-1947 (bulk)</title>
+  </titleInfo>
+  <name usage="primary" type="personal">
+    <namePart>Ricketts, Edward Flanders</namePart>
+    <namePart type="date">1897-1948</namePart>
+  </name>
+  <genre>Charts.</genre>
+  <genre>Graphs.</genre>
+  <genre>Notebooks.</genre>
+  <genre>Photoprints.</genre>
+  <genre>Surveys.</genre>
+  <typeOfResource manuscript="yes" collection="yes">mixed material</typeOfResource>
+  <physicalDescription>
+    <extent>7.5 linear feet</extent>
+  </physicalDescription>
+  <language>
+    <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+  </language>
+  <abstract displayLabel="Summary">Personal and professional papers including incoming and outgoing correspondence, a few letters from Herbert Kline to John Steinbeck, notes on intertidal marine life, printed articles, manuscript notes of unpublished biology articles, a philosophical manuscript, financial records, photographs and notes from trips to West Vancouver Island and the Queen Charlotte Islands prepared by Ricketts for the use of John Steinbeck. Also includes notes and other materials used for additions and revisions of Ricketts' publication, Between Pacific Tides, and correspondence about the book.</abstract>
+  <note type="acquisition">Transfer from Hopkins Marine Station, 1974, and Peter Lisca, 1991.</note>
+  <note type="biographical/historical">Edward Flanders Robb Ricketts was born in Chicago, Illinois May 14, 1897. From 1923 until his death in 1948, Ricketts lived in the Monterey, California area where he pursued his career as a marine biologist and became good friends with John Steinbeck.</note>
+  <note>Finding aid available in Special Collections Reading Room and online.</note>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Belloc, Hilary</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Belloc, Hope</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Berkeley, Cyril</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Cage, Xenia</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Campbell, Joseph</namePart>
+      <namePart type="date">1904-1987</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Genton, Élisabeth</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Faure, Raoul C</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Field, Sara Bard</namePart>
+      <namePart type="date">1882-1974</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Hedgepeth, Joel W</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Kline, Herbert</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Miller, Henry</namePart>
+      <namePart type="date">1891-1980</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Scardigli, Virginia</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Steinbeck, John</namePart>
+      <namePart type="date">1902-1968</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Street, Webster</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="personal">
+      <namePart>Wood, Charles Erskine Scott</namePart>
+      <namePart type="date">1852-1944</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="corporate">
+      <namePart>American Museum of Natural History.</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <name type="corporate">
+      <namePart>Pacific Biological Laboratories.</namePart>
+    </name>
+  </subject>
+  <subject authority="lcsh">
+    <topic>Oceanography</topic>
+    <geographic>Pacific Ocean</geographic>
+  </subject>
+  <subject authority="lcsh">
+    <topic>Marine biology</topic>
+    <topic>Research</topic>
+  </subject>
+  <subject authority="lcsh">
+    <topic>Marine ecology</topic>
+  </subject>
+  <originInfo>
+    <dateIssued encoding="marc" point="start">1936</dateIssued>
+    <dateIssued encoding="marc" point="end">1979</dateIssued>
+    <place>
+      <placeTerm authority="marccountry" type="code">cau</placeTerm>
+    </place>
+    <issuance>monographic</issuance>
+  </originInfo>
+  <location>
+    <url usage="primary display">https://purl.stanford.edu/ss099gb5528</url>
+  </location>
+  <location>
+    <physicalLocation>Department of Special Collections, Stanford University Libraries, Stanford, CA 94305.</physicalLocation>
+  </location>
+  <recordInfo>
+    <recordContentSource authority="marcorg">CSt</recordContentSource>
+    <descriptionStandard>dacs</descriptionStandard>
+    <recordOrigin>Converted from MARCXML to MODS version 3.6 using MARC21slim2MODS3-6_SDR.xsl (SUL version 1 2018/06/13; LC Revision 1.118 2018/01/31)</recordOrigin>
+    <recordCreationDate encoding="marc">840507</recordCreationDate>
+    <recordIdentifier source="SIRSI">a4082962</recordIdentifier>
+  </recordInfo>
+  <relatedItem>
+    <location>
+      <url displayLabel="Finding aid available online">http://www.oac.cdlib.org/findaid/ark:/13030/tf2b69n5sx</url>
+    </location>
+  </relatedItem>
+  <accessCondition type="useAndReproduction">While Special Collections is the owner of the physical and digital items, permission to examine collection materials is not an authorization to publish. These materials are made available for use in research, teaching, and private study. Any transmission or reproduction beyond that allowed by fair use requires permission from the owners of rights, heir(s) or assigns. See: http://library.stanford.edu/spc/using-collections/permission-publish</accessCondition>
+  <accessCondition type="copyright">Materials may be subject to copyright.</accessCondition>
+</mods>

--- a/spec/fixtures/document_cache/ss/099/gb/5528/public
+++ b/spec/fixtures/document_cache/ss/099/gb/5528/public
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:ss099gb5528" published="2023-04-18T21:15:57Z" publishVersion="cocina-models/0.90.0">
+  <identityMetadata>
+    <objectType>collection</objectType>
+    <objectLabel>Edward Flanders Ricketts papers, 1936-1979 (inclusive), 1936-1947 (bulk)</objectLabel>
+    <otherId name="catkey">4082962</otherId>
+    <otherId name="folio_instance_hrid">a4082962</otherId>
+  </identityMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">While Special Collections is the owner of the physical and digital items, permission to examine collection materials is not an authorization to publish. These materials are made available for use in research, teaching, and private study. Any transmission or reproduction beyond that allowed by fair use requires permission from the owners of rights, heir(s) or assigns. See: http://library.stanford.edu/spc/using-collections/permission-publish</human>
+      <license/>
+    </use>
+    <copyright>
+      <human>Materials may be subject to copyright.</human>
+    </copyright>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:ss099gb5528">
+    
+    
+  </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Edward Flanders Ricketts papers, 1936-1979 (inclusive), 1936-1947 (bulk)</dc:title>
+    <dc:contributor>Ricketts, Edward Flanders, 1897-1948</dc:contributor>
+    <dc:type>Charts.</dc:type>
+    <dc:type>Graphs.</dc:type>
+    <dc:type>Notebooks.</dc:type>
+    <dc:type>Photoprints.</dc:type>
+    <dc:type>Surveys.</dc:type>
+    <dc:type>Collection</dc:type>
+    <dc:format>7.5 linear feet</dc:format>
+    <dc:language>eng</dc:language>
+    <dc:description displayLabel="Summary">Personal and professional papers including incoming and outgoing correspondence, a few letters from Herbert Kline to John Steinbeck, notes on intertidal marine life, printed articles, manuscript notes of unpublished biology articles, a philosophical manuscript, financial records, photographs and notes from trips to West Vancouver Island and the Queen Charlotte Islands prepared by Ricketts for the use of John Steinbeck. Also includes notes and other materials used for additions and revisions of Ricketts' publication, Between Pacific Tides, and correspondence about the book.</dc:description>
+    <dc:description type="acquisition">Transfer from Hopkins Marine Station, 1974, and Peter Lisca, 1991.</dc:description>
+    <dc:description type="biographical/historical">Edward Flanders Robb Ricketts was born in Chicago, Illinois May 14, 1897. From 1923 until his death in 1948, Ricketts lived in the Monterey, California area where he pursued his career as a marine biologist and became good friends with John Steinbeck.</dc:description>
+    <dc:description>Finding aid available in Special Collections Reading Room and online.</dc:description>
+    <dc:subject>Belloc, Hilary</dc:subject>
+    <dc:subject>Belloc, Hope</dc:subject>
+    <dc:subject>Berkeley, Cyril</dc:subject>
+    <dc:subject>Cage, Xenia</dc:subject>
+    <dc:subject>Campbell, Joseph, 1904-1987</dc:subject>
+    <dc:subject>Genton, Élisabeth</dc:subject>
+    <dc:subject>Faure, Raoul C</dc:subject>
+    <dc:subject>Field, Sara Bard, 1882-1974</dc:subject>
+    <dc:subject>Hedgepeth, Joel W</dc:subject>
+    <dc:subject>Kline, Herbert</dc:subject>
+    <dc:subject>Miller, Henry, 1891-1980</dc:subject>
+    <dc:subject>Scardigli, Virginia</dc:subject>
+    <dc:subject>Steinbeck, John, 1902-1968</dc:subject>
+    <dc:subject>Street, Webster</dc:subject>
+    <dc:subject>Wood, Charles Erskine Scott, 1852-1944</dc:subject>
+    <dc:subject>American Museum of Natural History.</dc:subject>
+    <dc:subject>Pacific Biological Laboratories.</dc:subject>
+    <dc:subject>Oceanography</dc:subject>
+    <dc:coverage>Pacific Ocean</dc:coverage>
+    <dc:subject>Oceanography--Pacific Ocean</dc:subject>
+    <dc:subject>Marine biology--Research</dc:subject>
+    <dc:subject>Marine ecology</dc:subject>
+    <dc:date>1936-1979</dc:date>
+    <dc:identifier>https://purl.stanford.edu/ss099gb5528</dc:identifier>
+    <dc:rights>Open for research; material must be requested at least 36 hours in advance of intended use.</dc:rights>
+    <dc:relation type="url" href="http://www.oac.cdlib.org/findaid/ark:/13030/tf2b69n5sx"/>
+  </oai_dc:dc>
+  <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+    <titleInfo>
+      <title>Edward Flanders Ricketts papers, 1936-1979 (inclusive), 1936-1947 (bulk)</title>
+    </titleInfo>
+    <name usage="primary" type="personal">
+      <namePart>Ricketts, Edward Flanders</namePart>
+      <namePart type="date">1897-1948</namePart>
+    </name>
+    <genre>Charts.</genre>
+    <genre>Graphs.</genre>
+    <genre>Notebooks.</genre>
+    <genre>Photoprints.</genre>
+    <genre>Surveys.</genre>
+    <typeOfResource manuscript="yes" collection="yes">mixed material</typeOfResource>
+    <physicalDescription>
+      <extent>7.5 linear feet</extent>
+    </physicalDescription>
+    <language>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+    </language>
+    <abstract displayLabel="Summary">Personal and professional papers including incoming and outgoing correspondence, a few letters from Herbert Kline to John Steinbeck, notes on intertidal marine life, printed articles, manuscript notes of unpublished biology articles, a philosophical manuscript, financial records, photographs and notes from trips to West Vancouver Island and the Queen Charlotte Islands prepared by Ricketts for the use of John Steinbeck. Also includes notes and other materials used for additions and revisions of Ricketts' publication, Between Pacific Tides, and correspondence about the book.</abstract>
+    <note type="acquisition">Transfer from Hopkins Marine Station, 1974, and Peter Lisca, 1991.</note>
+    <note type="biographical/historical">Edward Flanders Robb Ricketts was born in Chicago, Illinois May 14, 1897. From 1923 until his death in 1948, Ricketts lived in the Monterey, California area where he pursued his career as a marine biologist and became good friends with John Steinbeck.</note>
+    <note>Finding aid available in Special Collections Reading Room and online.</note>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Belloc, Hilary</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Belloc, Hope</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Berkeley, Cyril</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Cage, Xenia</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Campbell, Joseph</namePart>
+        <namePart type="date">1904-1987</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Genton, Élisabeth</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Faure, Raoul C</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Field, Sara Bard</namePart>
+        <namePart type="date">1882-1974</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Hedgepeth, Joel W</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Kline, Herbert</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Miller, Henry</namePart>
+        <namePart type="date">1891-1980</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Scardigli, Virginia</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Steinbeck, John</namePart>
+        <namePart type="date">1902-1968</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Street, Webster</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="personal">
+        <namePart>Wood, Charles Erskine Scott</namePart>
+        <namePart type="date">1852-1944</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="corporate">
+        <namePart>American Museum of Natural History.</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <name type="corporate">
+        <namePart>Pacific Biological Laboratories.</namePart>
+      </name>
+    </subject>
+    <subject authority="lcsh">
+      <topic>Oceanography</topic>
+      <geographic>Pacific Ocean</geographic>
+    </subject>
+    <subject authority="lcsh">
+      <topic>Marine biology</topic>
+      <topic>Research</topic>
+    </subject>
+    <subject authority="lcsh">
+      <topic>Marine ecology</topic>
+    </subject>
+    <originInfo>
+      <dateIssued encoding="marc" point="start">1936</dateIssued>
+      <dateIssued encoding="marc" point="end">1979</dateIssued>
+      <place>
+        <placeTerm authority="marccountry" type="code">cau</placeTerm>
+      </place>
+      <issuance>monographic</issuance>
+    </originInfo>
+    <location>
+      <url usage="primary display">https://purl.stanford.edu/ss099gb5528</url>
+    </location>
+    <location>
+      <physicalLocation>Department of Special Collections, Stanford University Libraries, Stanford, CA 94305.</physicalLocation>
+    </location>
+    <recordInfo>
+      <recordContentSource authority="marcorg">CSt</recordContentSource>
+      <descriptionStandard>dacs</descriptionStandard>
+      <recordOrigin>Converted from MARCXML to MODS version 3.6 using MARC21slim2MODS3-6_SDR.xsl (SUL version 1 2018/06/13; LC Revision 1.118 2018/01/31)</recordOrigin>
+      <recordCreationDate encoding="marc">840507</recordCreationDate>
+      <recordIdentifier source="SIRSI">a4082962</recordIdentifier>
+    </recordInfo>
+    <relatedItem>
+      <location>
+        <url displayLabel="Finding aid available online">http://www.oac.cdlib.org/findaid/ark:/13030/tf2b69n5sx</url>
+      </location>
+    </relatedItem>
+    <accessCondition type="useAndReproduction">While Special Collections is the owner of the physical and digital items, permission to examine collection materials is not an authorization to publish. These materials are made available for use in research, teaching, and private study. Any transmission or reproduction beyond that allowed by fair use requires permission from the owners of rights, heir(s) or assigns. See: http://library.stanford.edu/spc/using-collections/permission-publish</accessCondition>
+    <accessCondition type="copyright">Materials may be subject to copyright.</accessCondition>
+  </mods>
+</publicObject>

--- a/spec/views/purl/_collection_items.html.erb_spec.rb
+++ b/spec/views/purl/_collection_items.html.erb_spec.rb
@@ -31,4 +31,14 @@ RSpec.describe 'purl/_collection_items' do
       expect(rendered).not_to have_css 'a'
     end
   end
+
+  context 'when not released to SearchWorks' do
+    let(:purl) { PurlResource.new(id: 'ss099gb5528') }
+
+    it 'does not display View items in this collection link' do
+      # render
+      render 'purl/collection_items', document: purl
+      expect(rendered).not_to have_css 'a'
+    end
+  end
 end


### PR DESCRIPTION
Previously, for collections that were in SW but the collection was not released to SW the link would be rendered. However, there would be no results in SW.

For example, https://purl.stanford.edu/cd027gx5097

![image](https://github.com/sul-dlss/purl/assets/588335/ca1effb1-f846-4836-9d97-68417097a0cb)
