### PR TITLE
Remove feedback form from importmap.

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,6 +9,5 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin_all_from "app/javascript/preview_controllers", under: "preview_controllers"
 # Preview is a separate application to avoid loading ace-builds for every page
 pin 'preview_application'
-pin 'feedback_form'
 pin "ace-builds", to: "https://ga.jspm.io/npm:ace-builds@1.16.0/src-noconflict/ace.js"
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true


### PR DESCRIPTION
I forgot to remove it when refactoring feedback form.

```
08:01:37 web.1  | Importmap skipped missing path: feedback_form.js
```