### PR TITLE
Add noindex meta when not world download.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ The RuboCop style enforcement can be run without running the tests
 ## Deploying
 
 Deployment is handled automatically via Jenkins when a release is published to GitHub.
+
+## Search engine indexing
+
+The current policy is to only index items that have world view and download rights.
+
+To this end, only world view and download right items are included in the sitemap and all other items have a "noindex" meta tag.

--- a/app/models/rights_metadata.rb
+++ b/app/models/rights_metadata.rb
@@ -13,7 +13,7 @@ class RightsMetadata
 
   delegate :stanford_only_rights_for_file, :world_rights_for_file, :stanford_only_unrestricted_file?,
            :restricted_by_location?, :world_downloadable_file?, :stanford_only_downloadable_file?,
-           :cdl_rights_for_file, :controlled_digital_lending?, to: :rights_auth
+           :cdl_rights_for_file, :controlled_digital_lending?, :world_downloadable?, to: :rights_auth
 
   def use_and_reproduction_statement
     document.at_xpath('use/human[@type="useAndReproduction"]').try(:text)

--- a/app/views/purl/show.html.erb
+++ b/app/views/purl/show.html.erb
@@ -11,6 +11,7 @@
   <%= tag :link, rel: "up", href: purl_url(@purl.containing_collections.first) if @purl.containing_collections.present? %>
   <%= tag :meta, name: 'citation_doi', content: @purl.doi_id if @purl.doi.present? %>
   <%= tag :meta, name: 'citation_title', content: @purl.title %>
+  <%= tag :meta, name: 'robots', content: 'noindex' unless @purl.rights.world_downloadable? %>
 <% end %>
 
 <% keywords(@purl.mods.subject.compact.map(&:values).join(',')) if @purl.mods? && @purl.mods.subject %>

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -203,6 +203,20 @@ RSpec.describe 'Integration Scenarios' do
     end
   end
 
+  context 'citation only item' do
+    it 'includes noindex meta tag' do
+      visit '/bb000br0025'
+      expect(page).to have_selector 'meta[name="robots"][content="noindex"]', visible: :hidden
+    end
+  end
+
+  context 'world-downloadable item' do
+    it 'excludes noindex meta tag' do
+      visit '/nd387jf5675'
+      expect(page).not_to have_selector 'meta[name="robots"][content="noindex"]', visible: :hidden
+    end
+  end
+
   def have_metadata_section(text)
     have_selector '.section-heading', text:
   end

--- a/spec/fixtures/document_cache/bb/000/br/0025/mods
+++ b/spec/fixtures/document_cache/bb/000/br/0025/mods
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+  <titleInfo usage="primary">
+    <title>Drug enforcement</title>
+  </titleInfo>
+  <titleInfo type="abbreviated">
+    <title>Drug enforc</title>
+  </titleInfo>
+  <name type="corporate">
+    <namePart>United States</namePart>
+    <namePart>Drug Enforcement Administration</namePart>
+  </name>
+  <genre authority="marcgt">periodical</genre>
+  <typeOfResource>text</typeOfResource>
+  <physicalDescription>
+    <form authority="marcform">print</form>
+    <extent>12 v. : ill. (some col.) ; 28 cm.</extent>
+  </physicalDescription>
+  <language>
+    <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+  </language>
+  <note type="date/sequential designation">Vol. 1, no. 1 (fall 1973)-</note>
+  <note type="date/sequential designation">Ceased with v. 12, no. 1, summer 1985.</note>
+  <note>Title from cover.</note>
+  <note type="additional physical form">Also issued online.</note>
+  <subject authority="marcgac">
+    <geographicCode>n-us</geographicCode>
+  </subject>
+  <subject authority="lcsh">
+    <topic>Drug control</topic>
+    <geographic>United States</geographic>
+    <genre>Periodicals</genre>
+  </subject>
+  <subject authority="lcsh">
+    <topic>Drug control</topic>
+    <topic>International cooperation</topic>
+    <genre>Periodicals</genre>
+  </subject>
+  <subject authority="lcsh">
+    <topic>Drugs</topic>
+    <genre>Periodicals</genre>
+  </subject>
+  <subject authority="mesh">
+    <topic>Drug and Narcotic Control</topic>
+    <geographic>United States</geographic>
+    <genre>Periodicals</genre>
+  </subject>
+  <subject authority="embne">
+    <topic>Drogas</topic>
+    <topic>Control</topic>
+  </subject>
+  <classification authority="lcc">HV5825 .D7763</classification>
+  <classification authority="nlm">W1 DR521D</classification>
+  <classification authority="ddc">363.4/5/0973</classification>
+  <originInfo>
+    <dateIssued encoding="marc" point="start">1973</dateIssued>
+    <dateIssued encoding="marc" point="end">1985</dateIssued>
+    <place>
+      <placeTerm authority="marccountry" type="code">dcu</placeTerm>
+    </place>
+    <issuance>serial</issuance>
+    <frequency authority="marcfrequency">Completely
+                irregular</frequency>
+  </originInfo>
+  <originInfo>
+    <dateIssued>[1973-</dateIssued>
+    <place>
+      <placeTerm type="text">[Washington, D.C.]</placeTerm>
+    </place>
+    <publisher>Drug Enforcement Administration, U.S. Dept. of Justice</publisher>
+    <frequency>Irregular</frequency>
+  </originInfo>
+  <identifier type="issn">0098-3470</identifier>
+  <identifier type="issn-l">0098-3470</identifier>
+  <identifier type="lccn">75647777</identifier>
+  <identifier type="stock-number">Supt. of Docs., U.S. Govt. Print. Off., Washington, D.C. 20402</identifier>
+  <location>
+    <url usage="primary display">https://purl.stanford.edu/bb000br0025</url>
+  </location>
+  <location>
+    <url displayLabel="Full text via HathiTrust">https://catalog.hathitrust.org/Record/000637716</url>
+  </location>
+  <recordInfo>
+    <languageOfCataloging>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+    </languageOfCataloging>
+    <recordContentSource authority="marcorg">DLC</recordContentSource>
+    <descriptionStandard>aacr</descriptionStandard>
+    <recordOrigin>Converted from MARCXML to MODS version 3.7 using
+      MARC21slim2MODS3-7_SDR_v2-6.xsl (SUL 3.7 version 2.6 20220603; LC Revision 1.140
+      20200717)</recordOrigin>
+    <recordCreationDate encoding="marc">760127</recordCreationDate>
+    <recordChangeDate encoding="iso8601">20131024111120.0</recordChangeDate>
+    <recordIdentifier source="SIRSI">a3234065</recordIdentifier>
+  </recordInfo>
+  <relatedItem type="otherFormat" displayLabel="Online version:">
+    <titleInfo>
+      <title>Drug enforcement</title>
+    </titleInfo>
+    <identifier>(OCoLC)564636876</identifier>
+  </relatedItem>
+  <relatedItem type="preceding">
+    <titleInfo>
+      <title>BNDD bulletin</title>
+    </titleInfo>
+    <identifier type="issn">0049-5468</identifier>
+    <identifier>(DLC)   75647641</identifier>
+  </relatedItem>
+  <relatedItem type="host">
+    <titleInfo>
+      <title>Google Books</title>
+    </titleInfo>
+    <location>
+      <url>https://purl.stanford.edu/yh583fk3400</url>
+    </location>
+    <typeOfResource collection="yes"/>
+  </relatedItem>
+</mods>

--- a/spec/fixtures/document_cache/bb/000/br/0025/public
+++ b/spec/fixtures/document_cache/bb/000/br/0025/public
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:bb000br0025" published="2023-04-07T20:50:29Z" publishVersion="cocina-models/0.90.0">
+  <identityMetadata>
+    <objectType>item</objectType>
+    <objectLabel>Drug enforcement</objectLabel>
+    <otherId name="catkey">3234065</otherId>
+    <otherId name="folio_instance_hrid">a3234065</otherId>
+    <sourceId source="sul">googlebooks:stanford_36105123784501</sourceId>
+    <otherId name="barcode">36105123784501</otherId>
+  </identityMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <none/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction"/>
+      <license/>
+    </use>
+    <copyright>
+      <human/>
+    </copyright>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:bb000br0025">
+      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:yh583fk3400"/>
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Drug enforcement</dc:title>
+    <dc:title>Drug enforc</dc:title>
+    <dc:contributor>United States Drug Enforcement Administration</dc:contributor>
+    <dc:type>periodical</dc:type>
+    <dc:type>Text</dc:type>
+    <dc:format>12 v. : ill. (some col.) ; 28 cm.</dc:format>
+    <dc:format>print</dc:format>
+    <dc:language>eng</dc:language>
+    <dc:description type="date/sequential designation">Vol. 1, no. 1 (fall 1973)-</dc:description>
+    <dc:description type="date/sequential designation">Ceased with v. 12, no. 1, summer 1985.</dc:description>
+    <dc:description>Title from cover.</dc:description>
+    <dc:description type="additional physical form">Also issued online.</dc:description>
+    <dc:subject>Drug control</dc:subject>
+    <dc:coverage>United States</dc:coverage>
+    <dc:subject>Drug control--United States--Periodicals</dc:subject>
+    <dc:subject>Drug control--International cooperation</dc:subject>
+    <dc:subject>Drug control--International cooperation--Periodicals</dc:subject>
+    <dc:subject>Drugs</dc:subject>
+    <dc:subject>Drugs--Periodicals</dc:subject>
+    <dc:subject>Drug and Narcotic Control</dc:subject>
+    <dc:coverage>United States</dc:coverage>
+    <dc:subject>Drug and Narcotic Control--United States--Periodicals</dc:subject>
+    <dc:subject>Drogas--Control</dc:subject>
+    <dc:subject>HV5825 .D7763</dc:subject>
+    <dc:subject>W1 DR521D</dc:subject>
+    <dc:subject>363.4/5/0973</dc:subject>
+    <dc:date>1973-1985</dc:date>
+    <dc:date>[1973-</dc:date>
+    <dc:publisher>Drug Enforcement Administration, U.S. Dept. of Justice</dc:publisher>
+    <dc:identifier>issn: 0098-3470</dc:identifier>
+    <dc:identifier>0098-3470</dc:identifier>
+    <dc:identifier>lccn: 75647777</dc:identifier>
+    <dc:identifier>Supt. of Docs., U.S. Govt. Print. Off., Washington, D.C. 20402</dc:identifier>
+    <dc:identifier>https://purl.stanford.edu/bb000br0025</dc:identifier>
+    <dc:identifier>https://catalog.hathitrust.org/Record/000637716</dc:identifier>
+    <dc:relation>Drug enforcement--(OCoLC)564636876</dc:relation>
+    <dc:relation>BNDD bulletin--0049-5468--(DLC)   75647641</dc:relation>
+    <dc:relation type="collection">Google Books</dc:relation>
+  </oai_dc:dc>
+  <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+    <titleInfo usage="primary">
+      <title>Drug enforcement</title>
+    </titleInfo>
+    <titleInfo type="abbreviated">
+      <title>Drug enforc</title>
+    </titleInfo>
+    <name type="corporate">
+      <namePart>United States</namePart>
+      <namePart>Drug Enforcement Administration</namePart>
+    </name>
+    <genre authority="marcgt">periodical</genre>
+    <typeOfResource>text</typeOfResource>
+    <physicalDescription>
+      <form authority="marcform">print</form>
+      <extent>12 v. : ill. (some col.) ; 28 cm.</extent>
+    </physicalDescription>
+    <language>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+    </language>
+    <note type="date/sequential designation">Vol. 1, no. 1 (fall 1973)-</note>
+    <note type="date/sequential designation">Ceased with v. 12, no. 1, summer 1985.</note>
+    <note>Title from cover.</note>
+    <note type="additional physical form">Also issued online.</note>
+    <subject authority="marcgac">
+      <geographicCode>n-us</geographicCode>
+    </subject>
+    <subject authority="lcsh">
+      <topic>Drug control</topic>
+      <geographic>United States</geographic>
+      <genre>Periodicals</genre>
+    </subject>
+    <subject authority="lcsh">
+      <topic>Drug control</topic>
+      <topic>International cooperation</topic>
+      <genre>Periodicals</genre>
+    </subject>
+    <subject authority="lcsh">
+      <topic>Drugs</topic>
+      <genre>Periodicals</genre>
+    </subject>
+    <subject authority="mesh">
+      <topic>Drug and Narcotic Control</topic>
+      <geographic>United States</geographic>
+      <genre>Periodicals</genre>
+    </subject>
+    <subject authority="embne">
+      <topic>Drogas</topic>
+      <topic>Control</topic>
+    </subject>
+    <classification authority="lcc">HV5825 .D7763</classification>
+    <classification authority="nlm">W1 DR521D</classification>
+    <classification authority="ddc">363.4/5/0973</classification>
+    <originInfo>
+      <dateIssued encoding="marc" point="start">1973</dateIssued>
+      <dateIssued encoding="marc" point="end">1985</dateIssued>
+      <place>
+        <placeTerm authority="marccountry" type="code">dcu</placeTerm>
+      </place>
+      <issuance>serial</issuance>
+      <frequency authority="marcfrequency">Completely
+									irregular</frequency>
+    </originInfo>
+    <originInfo>
+      <dateIssued>[1973-</dateIssued>
+      <place>
+        <placeTerm type="text">[Washington, D.C.]</placeTerm>
+      </place>
+      <publisher>Drug Enforcement Administration, U.S. Dept. of Justice</publisher>
+      <frequency>Irregular</frequency>
+    </originInfo>
+    <identifier type="issn">0098-3470</identifier>
+    <identifier type="issn-l">0098-3470</identifier>
+    <identifier type="lccn">75647777</identifier>
+    <identifier type="stock-number">Supt. of Docs., U.S. Govt. Print. Off., Washington, D.C. 20402</identifier>
+    <location>
+      <url usage="primary display">https://purl.stanford.edu/bb000br0025</url>
+    </location>
+    <location>
+      <url displayLabel="Full text via HathiTrust">https://catalog.hathitrust.org/Record/000637716</url>
+    </location>
+    <recordInfo>
+      <languageOfCataloging>
+        <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+      </languageOfCataloging>
+      <recordContentSource authority="marcorg">DLC</recordContentSource>
+      <descriptionStandard>aacr</descriptionStandard>
+      <recordOrigin>Converted from MARCXML to MODS version 3.7 using
+				MARC21slim2MODS3-7_SDR_v2-6.xsl (SUL 3.7 version 2.6 20220603; LC Revision 1.140
+				20200717)</recordOrigin>
+      <recordCreationDate encoding="marc">760127</recordCreationDate>
+      <recordChangeDate encoding="iso8601">20131024111120.0</recordChangeDate>
+      <recordIdentifier source="SIRSI">a3234065</recordIdentifier>
+    </recordInfo>
+    <relatedItem type="otherFormat" displayLabel="Online version:">
+      <titleInfo>
+        <title>Drug enforcement</title>
+      </titleInfo>
+      <identifier>(OCoLC)564636876</identifier>
+    </relatedItem>
+    <relatedItem type="preceding">
+      <titleInfo>
+        <title>BNDD bulletin</title>
+      </titleInfo>
+      <identifier type="issn">0049-5468</identifier>
+      <identifier>(DLC)   75647641</identifier>
+    </relatedItem>
+    <relatedItem type="host">
+      <titleInfo>
+        <title>Google Books</title>
+      </titleInfo>
+      <location>
+        <url>https://purl.stanford.edu/yh583fk3400</url>
+      </location>
+      <typeOfResource collection="yes"/>
+    </relatedItem>
+  </mods>
+</publicObject>


### PR DESCRIPTION
This is part of opening up world download items to google indexing. It specifically prevents the opposite -- indexing items that are not world download by adding a noindex meta tag.

refs #774