### PR TITLE
Require action_cable/engine

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require "active_model/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
+require "action_cable/engine"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
turbo-rails requires ActionCable so we need to include it. Fixes:

```
 An error occurred while loading ./spec/controller/feedback_forms_controller_spec.rb.
Failure/Error: require File.expand_path('../config/environment', __dir__)

NameError:
  uninitialized constant ActionCable
# ./vendor/bundle/ruby/3.2.0/gems/turbo-rails-1.5.0/app/channels/turbo/streams_channel.rb:34:in `<top (required)>'
```