### PR TITLE
Disable no script for recaptcha.

### DIFF
--- a/app/views/feedback_forms/new.html.erb
+++ b/app/views/feedback_forms/new.html.erb
@@ -34,7 +34,8 @@
           <% if current_user.blank? %>
             <div class="form-group row mb-3">
               <div class="offset-sm-3 col-sm-9">
-                <%= recaptcha_tags %>
+                <%# no_script causes multiple response parameters to be submitted, which breaks verification. %>
+                <%= recaptcha_tags noscript: false %>
 
                 <p>(Stanford users can avoid this Captcha by logging in.)</p>
               </div>


### PR DESCRIPTION
closes #820

Tested in production.

The feedback form was not working due to:
1. Passenger bug was causing cookies to be broken.
2. 2 recaptcha response params were being included (one from noscript), which was causing recaptcha verification to fail.