### PR TITLE
Shorten the distance between metrics headings and counts

### DIFF
--- a/app/assets/stylesheets/modules/record-metadata-section.scss
+++ b/app/assets/stylesheets/modules/record-metadata-section.scss
@@ -46,9 +46,10 @@
 }
 
 .metrics dl {
-  max-width: 40ch;
+  max-width: fit-content;
   display: grid;
   grid-template-columns: 1fr auto;
+  column-gap: 2em;
   row-gap: 0.5em;
 
   dt, dd {
@@ -62,5 +63,9 @@
     font-size: inherit;
     color: inherit;
     text-transform: none !important;
+  }
+
+  dd {
+    text-align: right;
   }
 }


### PR DESCRIPTION
requested by @amyehodge via slack. since we're only showing the one metric right now (and eventually only two), having the big padding in between the heading and count looks a little weird.

before:

![Screenshot 2023-11-28 at 09 02 34](https://github.com/sul-dlss/purl/assets/4924494/2dc09762-e538-4dc3-bebb-0002a8a87074)


after:

![Screenshot 2023-11-28 at 09 02 30](https://github.com/sul-dlss/purl/assets/4924494/bcd443d2-b82d-4baa-9ef8-cf65bd369660)
