### PR TITLE
Temporary placeholder before the embed loads.

### DIFF
--- a/app/javascript/controllers/oembed_controller.js
+++ b/app/javascript/controllers/oembed_controller.js
@@ -1,10 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class OembedController extends Controller {
-  static values = {
-    url: String
-  }
-
   connect() {
     const loadedAttr = this.element.getAttribute('loaded')
 
@@ -14,7 +10,7 @@ export default class OembedController extends Controller {
 
     const oEmbedEndPoint = document.head.querySelector('link[rel="alternate"][type="application/json+oembed"]')?.getAttribute('href')
     if (!oEmbedEndPoint) {
-      console.warn(`No oEmbed endpoint found in <head> at ${this.urlValue}`)
+      console.warn(`No oEmbed endpoint found in <head>`)
       return
     }
     this.loadEndPoint(oEmbedEndPoint)

--- a/app/views/purl/_embed.html.erb
+++ b/app/views/purl/_embed.html.erb
@@ -1,4 +1,8 @@
 <%= tag.div data: { controller: 'oembed', oembed_url_value: embeddable_url(@purl.druid) } do %>
+  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false">
+    <title>Placeholder</title>
+    <rect width="100%" height="100%" fill="#868e96"></rect>
+  </svg>
   <a class="purl-embed-viewer embed" href="<%= embeddable_url(@purl.druid) %>" data-oembed-provider="<%= oembed_provider_url %>">Show Content</a>
 <% end %>
 <noscript>

--- a/app/views/purl/_embed.html.erb
+++ b/app/views/purl/_embed.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div data: { controller: 'oembed', oembed_url_value: embeddable_url(@purl.druid) } do %>
+<%= tag.div data: { controller: 'oembed' } do %>
   <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder" preserveAspectRatio="xMidYMid slice" focusable="false">
     <title>Placeholder</title>
     <rect width="100%" height="100%" fill="#868e96"></rect>

--- a/app/views/purl/show.html.erb
+++ b/app/views/purl/show.html.erb
@@ -44,11 +44,13 @@ end
 
 %>
 <h1><%= @purl.title %></h1>
+<% if @purl.embeddable? %>
 <div class="upper-record-metadata row">
   <div class="col-md-12">
     <%= render 'embed' %>
   </div>
 </div>
+<% end %>
 
 <div class="record-metadata row gx-5">
   <div class="record-sections col-lg-8">


### PR DESCRIPTION
This prevents the content from jumping around