### PR TITLE
use new split out fields instead of imprint from mods_display v1.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,8 @@ gem 'whenever', require: false # cron jobs
 # DLSS and its community
 gem 'dor-rights-auth', '~> 1.6'
 gem 'iiif-presentation', '~> 1.3'
-gem 'mods_display', '~> 1.5'
+#gem 'mods_display', '~> 1.5'
+gem 'mods_display', git: 'git@github.com:sul-dlss/mods_display', branch: 'date-other'
 
 group :production do
   gem 'newrelic_rpm'

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,7 @@ gem 'whenever', require: false # cron jobs
 # DLSS and its community
 gem 'dor-rights-auth', '~> 1.6'
 gem 'iiif-presentation', '~> 1.3'
-#gem 'mods_display', '~> 1.5'
-gem 'mods_display', git: 'git@github.com:sul-dlss/mods_display', branch: 'date-other'
+gem 'mods_display', '~> 1.6'
 
 group :production do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: git@github.com:sul-dlss/mods_display
+  revision: 2d449ce10bdca47419055d66cd09290a547dab81
+  branch: date-other
+  specs:
+    mods_display (1.5.0)
+      i18n
+      rails_autolink
+      stanford-mods (~> 3.3, >= 3.3.9)
+      view_component
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -189,7 +200,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashdiff (1.0.1)
-    honeybadger (5.3.0)
+    honeybadger (5.4.0)
     htmlentities (4.3.4)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -203,14 +214,14 @@ GEM
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.6.0)
-    irb (1.9.1)
+    irb (1.10.1)
       rdoc
       reline (>= 0.3.8)
     iso-639 (0.3.6)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.6.3)
+    json (2.7.0)
     jsonpath (1.1.5)
       multi_json
     language_server-protocol (3.17.0.3)
@@ -233,15 +244,10 @@ GEM
       iso-639
       nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
-    mods_display (1.5.0)
-      i18n
-      rails_autolink
-      stanford-mods (~> 3.3, >= 3.3.9)
-      view_component
     msgpack (1.7.2)
     multi_json (1.15.0)
     mutex_m (0.2.0)
-    net-imap (0.4.5)
+    net-imap (0.4.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -255,11 +261,13 @@ GEM
     net-ssh (7.2.0)
     newrelic_rpm (9.6.0)
       base64
-    nio4r (2.6.0)
+    nio4r (2.7.0)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
     nom-xml (1.2.0)
       i18n
@@ -323,10 +331,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
-    rdoc (6.6.0)
+    rdoc (6.6.1)
       psych (>= 4.0.0)
     recaptcha (5.16.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
     rexml (3.2.6)
@@ -338,7 +346,7 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (6.0.3)
+    rspec-rails (6.1.0)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
@@ -347,7 +355,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    rubocop (1.57.2)
+    rubocop (1.58.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -355,7 +363,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -437,7 +445,8 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-darwin-20
+  x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   addressable
@@ -461,7 +470,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jsonpath
-  mods_display (~> 1.5)
+  mods_display!
   newrelic_rpm
   okcomputer
   propshaft
@@ -486,4 +495,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.3.19
+   2.4.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: git@github.com:sul-dlss/mods_display
-  revision: 2d449ce10bdca47419055d66cd09290a547dab81
-  branch: date-other
-  specs:
-    mods_display (1.5.0)
-      i18n
-      rails_autolink
-      stanford-mods (~> 3.3, >= 3.3.9)
-      view_component
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -244,6 +233,11 @@ GEM
       iso-639
       nokogiri (>= 1.6.6)
       nom-xml (~> 1.0)
+    mods_display (1.6.0)
+      i18n
+      rails_autolink
+      stanford-mods (~> 3.3, >= 3.3.9)
+      view_component
     msgpack (1.7.2)
     multi_json (1.15.0)
     mutex_m (0.2.0)
@@ -470,7 +464,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jsonpath
-  mods_display!
+  mods_display (~> 1.6)
   newrelic_rpm
   okcomputer
   propshaft

--- a/app/views/purl/_mods_description.html.erb
+++ b/app/views/purl/_mods_description.html.erb
@@ -1,6 +1,15 @@
 <% fields = document.mods.mods_field(:title).fields.reject { |x| x.label =~ /^Title/i } +
             document.mods.resourceType + document.mods.form + document.mods.extent +
-            document.mods.imprint + document.mods.language + document.mods.description +
+            document.mods.place + document.mods.publisher + document.mods.edition +
+            document.mods.dateCaptured +
+            document.mods.dateCreated +
+            document.mods.dateValid +
+            document.mods.dateModified +
+            document.mods.dateIssued +
+            document.mods.dateOther +
+            document.mods.copyrightDate +
+            document.mods.issuance + document.mods.frequency +
+            document.mods.language + document.mods.description +
             document.mods.cartographics
 %>
 <% if fields.present? %>


### PR DESCRIPTION
HOLDING for PO approval.

from thread on slack:  https://stanfordlib.slack.com/archives/C03FK9KB7TP/p1701803047039579

<img width="1392" alt="image" src="https://github.com/sul-dlss/purl/assets/96775/40e8cdca-e928-4754-975e-408462d543fc">



closes #845 except for the actual deploy of purl.