### PR TITLE
Add x86_64-linux platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.5-x86_64-linux)
+      racc (~> 1.4)
     nom-xml (1.2.0)
       i18n
       nokogiri
@@ -438,6 +440,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   addressable


### PR DESCRIPTION
I _think_ this could fix our dependency update issue where the build fails when attempting to install nokogiri.