### PR TITLE
Rescue errors in schema.org generation

### DIFF
--- a/lib/metadata/schema_dot_org.rb
+++ b/lib/metadata/schema_dot_org.rb
@@ -20,6 +20,9 @@ module Metadata
         "description": description }
         .merge(format_specific_fields)
         .compact
+    rescue StandardError
+      Honeybadger.notify('Error occurred generating schema.org markup', context: { druid: druid })
+      {}
     end
 
     def schema_type?
@@ -193,6 +196,8 @@ module Metadata
       # filenames need spaces escaped, while stacks expects other special characters such as ()
       escaped_filename = filename.gsub(' ', '%20')
       URI.join(Settings.stacks.url, "file/#{druid}/#{escaped_filename}").to_s
+    rescue URI::InvalidURIError
+      nil
     end
 
     def upload_date

--- a/spec/lib/metadata/schema_dot_org_spec.rb
+++ b/spec/lib/metadata/schema_dot_org_spec.rb
@@ -663,6 +663,37 @@ RSpec.describe Metadata::SchemaDotOrg do
       end
     end
 
+    context 'with a bad thumbnail filename' do
+      let(:cocina_json) do
+        <<~JSON
+          {
+            "externalIdentifier": "druid:tn153br1253",
+            "access": {"download": "world"},
+            "structural": {"contains": [{"type": "https://cocina.sul.stanford.edu/models/resources/video",
+                                        "structural": {
+                                                        "contains": [{"filename": "a_problem_thumb.jp2",
+                                                                      "hasMimeType": "image/jp2"},
+                                                                    {"filename": "tn153br1253_video_sl.mp4",
+                                                                      "access": { "view": "world",
+                                                                                    "download": "world",
+                                                                                    "controlledDigitalLending": false },
+                                                                      "hasMimeType": "video/mp4"}]
+                                                      }
+                                        }]
+                          }
+          }
+        JSON
+      end
+
+      before do
+        allow(URI).to receive(:join).and_raise(URI::InvalidURIError)
+      end
+
+      it 'rescues and returns nil' do
+        expect(schema_dot_org).not_to have_key('thumbnailUrl')
+      end
+    end
+
     context 'with an embeddable video' do
       it 'includes the embed_url' do
         expect(schema_dot_org).to include(


### PR DESCRIPTION
Rescue errors in thumbnailUrl generation or schema.org markup as a whole. 