### PR TITLE
Request bold weight of Source Sans 3 from google fonts

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
     <%= favicon_link_tag 'favicon.ico' %>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <%= stylesheet_link_tag "https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@300;400&display=swap" %>
+    <%= stylesheet_link_tag "https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@300;400;700&display=swap" %>
     <link rel="preload" href="<%= asset_path('DejaVuSans-ExtraLight-webfont.woff') %>" as="font" type="font/woff">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">


### PR DESCRIPTION
Fixes an issue identified in slack where table headers are not bold on chrome.