### PR TITLE
Update metrics date message

### DIFF
--- a/app/views/purl/_metrics.html.erb
+++ b/app/views/purl/_metrics.html.erb
@@ -22,7 +22,7 @@
       <p>No usage metrics available.</p>
     <% end %>
     <p>
-      Data collected since 11/20/23.
+      Data collected since 12/23.
       <a href="https://sdr.library.stanford.edu/sdr-metrics" class="su-underline">How are these metrics generated?</a>
     </p>
     <% if document.doi.present? %> 


### PR DESCRIPTION
Resolves #902 by having one date for both views and downloads, on all PURLs. 

@amyehodge here's the updated message:

![Screenshot 2023-12-14 at 10 54 36 AM](https://github.com/sul-dlss/purl/assets/1619369/acbfa503-8283-4aa3-8b11-e4ba994a7c0b)
