### PR TITLE
Add download metrics display for IIIF objects

### DIFF
--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -109,7 +109,7 @@ class PurlResource
 
   # Object types that we're able to track download metrics for
   def downloads_tracked?
-    %w[geo document file 3d media].include?(type)
+    %w[geo document file 3d media image book].include?(type)
   end
 
   def rights

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -73,18 +73,17 @@ RSpec.describe 'Metrics display', js: true do
       end
     end
 
-    # can't be downloaded
-    context 'when the object is a web archive' do
-      let(:druid) { 'bd802vw5233' }
+    context 'when the object is an image' do
+      let(:druid) { 'cp088pb1682' }
 
-      it 'does not show the number of downloads' do
-        expect(page).not_to have_selector '#download-count'
+      it 'shows the number of downloads' do
+        expect(page).to have_selector '#download-count', text: '1'
       end
     end
 
-    # no way to track as of 2023
-    context 'when the object is an image' do
-      let(:druid) { 'cp088pb1682' }
+    # can't be downloaded
+    context 'when the object is a web archive' do
+      let(:druid) { 'bd802vw5233' }
 
       it 'does not show the number of downloads' do
         expect(page).not_to have_selector '#download-count'


### PR DESCRIPTION
https://github.com/sul-dlss/stacks/pull/1086 enables tracking
serving and downloading IIIF images, so we can turn on display
of download metrics for objects with IIIF manifests.
