### PR TITLE
Provide the required label value for the active profile

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -300,11 +300,14 @@ class Iiif3PresentationManifest < IiifPresentationManifest
   end
 
   # The user will be required to visit the user interface of an external authentication system.
+  # https://iiif.io/api/auth/2.0/#active-interaction-pattern
   def iiif_v2_access_service_active
     IIIF::V3::Presentation::Service.new(
       'id' => "#{Settings.stacks.url}/auth/iiif",
       'type' => 'AuthAccessService2',
-      'profile' => 'active'
+      'profile' => 'active',
+      'label' => { 'en' =>  ['Stanford Login'] },
+      'confirmLabel' => { 'en' => ['Login'] }
     ).tap do |service|
       service.service = [iiif_v2_access_token_service]
     end


### PR DESCRIPTION
This is required in the spec. We're also adding confirmLabel so we know how to label the button.