### PR TITLE
Schema.org fixes for contributors

### DIFF
--- a/lib/metadata/schema_dot_org.rb
+++ b/lib/metadata/schema_dot_org.rb
@@ -135,7 +135,7 @@ module Metadata
 
     def creator_name(contributor)
       # contributor.name.value or concatenated contributor.name.structuredValue
-      JsonPath.new('$.name.value').first(contributor) || structured_name(contributor)
+      JsonPath.new('$.name[0].value').first(contributor) || structured_name(contributor)
     end
 
     def structured_name(contributor)
@@ -155,10 +155,10 @@ module Metadata
 
     def orcid(contributor)
       # contributor.identifier.uri or contributor.identifier.value with type "orcid" (case-insensitive), made into URI if identifier only
-      identifier = JsonPath.new('$.identifier.uri').first(contributor)
+      identifier = JsonPath.new('$.identifier[*].uri').first(contributor)
       return identifier if identifier.present?
 
-      orcid = JsonPath.new("$.identifier.[?(@['type'] == 'ORCID' || @['type'] == 'orcid')].value").first(contributor)
+      orcid = JsonPath.new("$.identifier[*].[?(@['type'] == 'ORCID' || @['type'] == 'orcid')].value").first(contributor)
       return if orcid.blank?
 
       return orcid if orcid.start_with?('https://orcid.org')

--- a/spec/lib/metadata/schema_dot_org_spec.rb
+++ b/spec/lib/metadata/schema_dot_org_spec.rb
@@ -419,8 +419,8 @@ RSpec.describe Metadata::SchemaDotOrg do
           {
             "description": { "form": [{ "value": "dataset",
                                         "type":  "genre" }],
-                            "contributor": [{"name": {"value": "Doe, Jane"}},
-                                            {"name": {"value": "Foo, John"}}]
+                            "contributor": [{"name": [{"value": "Doe, Jane"}]},
+                                            {"name": [{"value": "Foo, John"}]}]
                             }
           }
         JSON
@@ -491,8 +491,8 @@ RSpec.describe Metadata::SchemaDotOrg do
           {
             "description": { "form": [{ "value": "dataset",
                                         "type":  "genre" }],
-                            "contributor": [{"name": {"value": "Doe, Jane"},
-                                              "identifier": {"uri": "https://orcid.org/0000-0000-0000-0000"}}]
+                            "contributor": [{"name": [{"value": "Doe, Jane"}],
+                                             "identifier": [{"uri": "https://orcid.org/0000-0000-0000-0000"}]}]
                             }
           }
         JSON
@@ -515,9 +515,9 @@ RSpec.describe Metadata::SchemaDotOrg do
           {
             "description": { "form": [{ "value": "dataset",
                                         "type":  "genre" }],
-                            "contributor": [{"name": {"value": "Doe, Jane"},
-                                             "identifier": {"value": "0000-0000-0000-0000",
-                                                            "type": "ORCID"}
+                            "contributor": [{"name": [{"value": "Doe, Jane"}],
+                                             "identifier": [{"value": "0000-0000-0000-0000",
+                                                            "type": "ORCID"}]
                                             }]
                             }
           }
@@ -550,7 +550,7 @@ RSpec.describe Metadata::SchemaDotOrg do
                                       ]
                                   }
                                 ],
-                                "identifier": {"uri": "https://orcid.org/0000-0000-0000-0000"}
+                                "identifier": [{"uri": "https://orcid.org/0000-0000-0000-0000"}]
                               }]
                             }
           }


### PR DESCRIPTION
Fixes issue where names and ORCIDs were not being included in schema.org metadata. Resolves "creator"-related issues flagged by Google Search Console. 
