### PR TITLE
Only show download metrics for downloadable objects

### DIFF
--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -107,9 +107,11 @@ class PurlResource
     content_metadata.resources.present?
   end
 
-  # Object types that we're able to track download metrics for
-  def downloads_tracked?
-    %w[geo document file 3d media image book].include?(type)
+  # Show tracked downloads if the object has download permission and is a type that we track
+  # If we can't track downloads (e.g. for WARC), no point in showing the download count
+  def show_download_metrics?
+    (rights.world_downloadable? || rights.stanford_only_downloadable?) &&
+      %w[webarchive-seed webarchive-binary].exclude?(type)
   end
 
   def rights

--- a/app/models/rights_metadata.rb
+++ b/app/models/rights_metadata.rb
@@ -13,7 +13,8 @@ class RightsMetadata
 
   delegate :stanford_only_rights_for_file, :world_rights_for_file, :stanford_only_unrestricted_file?,
            :restricted_by_location?, :world_downloadable_file?, :stanford_only_downloadable_file?,
-           :cdl_rights_for_file, :controlled_digital_lending?, :world_downloadable?, to: :rights_auth
+           :cdl_rights_for_file, :controlled_digital_lending?, :world_downloadable?, :stanford_only_downloadable?,
+           to: :rights_auth
 
   def use_and_reproduction_statement
     document.at_xpath('use/human[@type="useAndReproduction"]').try(:text)

--- a/app/views/purl/_metrics.html.erb
+++ b/app/views/purl/_metrics.html.erb
@@ -3,13 +3,15 @@
   <%= render SectionComponent.new(label: 'Usage metrics', label_id: label_id) do %>
     <% if document.metrics.present? %>
       <%= render TableComponent.new(label_id: label_id, with_body: false) do %>
+      <% if document.embeddable? %>
       <tbody>
         <tr>
           <th>Views</th>
           <td id="view-count"><%= number_with_delimiter document.metrics['unique_views'] %></td>
         </tr>
       </tbody>
-      <% if document.downloads_tracked? %>
+      <% end %>
+      <% if document.show_download_metrics? %>
       <tbody>
         <tr>
           <th>Downloads</th>

--- a/app/views/purl/show.html.erb
+++ b/app/views/purl/show.html.erb
@@ -73,7 +73,7 @@ end
     <%= render "mods_contact", document: @purl %>
     <%= render "find_it", document: @purl %>
 
-    <% if @purl.embeddable? || @purl.doi.present? %>
+    <% if @purl.embeddable? || @purl.show_download_metrics? || @purl.doi.present? %>
       <turbo-frame id="metrics-frame" src="<%= purl_metrics_path @purl %>">
         <p>Loading usage metrics...</p>
       </turbo-frame>


### PR DESCRIPTION
This was tested with all the stanford-only/no-download versions of objects available in the spreadsheet, and the behavior seemed correct: if it is downloadable (including only by stanford), show the download count. Otherwise, don't.