### PR TITLE
change login messaging for auth

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -310,8 +310,8 @@ class Iiif3PresentationManifest < IiifPresentationManifest
       'id' => "#{Settings.stacks.url}/auth/iiif",
       'type' => 'AuthAccessService2',
       'profile' => 'active',
-      'label' => { 'en' =>  ['Stanford Login'] },
-      'confirmLabel' => { 'en' => ['Login'] }
+      'label' => { 'en' =>  ['Stanford users: log in to access all available features'] },
+      'confirmLabel' => { 'en' => ['Log in'] }
     ).tap do |service|
       service.service = [iiif_v2_access_token_service]
     end


### PR DESCRIPTION
Part of https://github.com/sul-dlss/sul-embed/issues/1919
Goes along with https://github.com/sul-dlss/sul-embed/pull/2032

Since we are going to use the responses coming back from the IIIF Auth service to show messaging to users, let's make it match the desired language in https://docs.google.com/document/d/1IIPYw4CVIaNCjPjtY427JxcPQngd5ZxgqhQLfhxVbi4/edit
