### PR TITLE
Make the druid regex strict

### DIFF
--- a/lib/dor/util.rb
+++ b/lib/dor/util.rb
@@ -2,7 +2,7 @@
 
 module Dor
   # constants
-  DRUID_REGEX = /^([a-z]{2})(\d{3})([a-z]{2})(\d{4})$/i
+  DRUID_REGEX = /\A([b-df-hjkmnp-tv-z]{2})([0-9]{3})([b-df-hjkmnp-tv-z]{2})([0-9]{4})\z/i
 
   PAIRTREE_REGEX = %r{/([a-z]{2})/(\d{3})/([a-z]{2})/(\d{4})}
 

--- a/spec/controller/purl_controller_spec.rb
+++ b/spec/controller/purl_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PurlController, type: :controller do
   it 'should render for a published item' do
-    get :show, params: { id: '/bb157hs6068' }
+    get :show, params: { id: 'bb157hs6068' }
   end
 
   it 'redirects to stacks urls' do

--- a/spec/integration/purl_spec.rb
+++ b/spec/integration/purl_spec.rb
@@ -7,11 +7,12 @@ RSpec.describe 'purl', type: :feature do
     @manifest_object = 'bc854fy5899'
     @embed_object = 'bf973rp9392'
     @annotation_list = 'hx163dc5225'
-    @unpublished_object = 'ab123cd4567'
     @legacy_object = 'ir:rs276tc2764'
     @nested_resources_object = 'dm907qj6498'
     @collection = 'bb631ry3167'
   end
+
+  let(:unpublished_object) { 'fb123cd4567' }
 
   describe 'manifest' do
     context 'v2' do
@@ -132,7 +133,7 @@ RSpec.describe 'purl', type: :feature do
 
   context 'incomplete/unpublished object (not in stacks)' do
     it 'gives 404 with unavailable message' do
-      visit "/#{@unpublished_object}"
+      visit "/#{unpublished_object}"
       expect(page.status_code).to eq(404)
       expect(page).to have_content 'The item you requested is not available.'
       expect(page).to have_content 'This item is in processing or does not exist. If you believe you have reached this page in error, please send Feedback.'
@@ -140,7 +141,7 @@ RSpec.describe 'purl', type: :feature do
 
     it 'includes a feedback link that toggled the feedback form', js: true do
       allow(Settings.feedback).to receive(:email_to).and_return('feedback@example.com')
-      visit "/#{@unpublished_object}"
+      visit "/#{unpublished_object}"
 
       expect(page).not_to have_css('form.feedback-form', visible: :visible)
 
@@ -160,7 +161,7 @@ RSpec.describe 'purl', type: :feature do
     end
 
     it '404 with unavailable message when no public_xml' do
-      visit "/#{@unpublished_object}.xml"
+      visit "/#{unpublished_object}.xml"
       expect(page.status_code).to eq(404)
       expect(page).to have_content 'The item you requested is not available.'
     end
@@ -174,7 +175,7 @@ RSpec.describe 'purl', type: :feature do
     end
 
     it '404 with unavailable message when no mods' do
-      visit "/#{@unpublished_object}.mods"
+      visit "/#{unpublished_object}.mods"
       expect(page.status_code).to eq(404)
       expect(page).to have_content 'The item you requested is not available.'
     end

--- a/spec/model/purl_resource_spec.rb
+++ b/spec/model/purl_resource_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe PurlResource do
 
     it 'validates that the object is "ready"' do
       allow_any_instance_of(described_class).to receive(:public_xml?).and_return(false)
-      expect { described_class.find('oo000oo0000') }.to raise_error PurlResource::ObjectNotReady
+      expect { described_class.find('bc000df0000') }.to raise_error PurlResource::ObjectNotReady
     end
   end
 
@@ -144,9 +144,9 @@ RSpec.describe PurlResource do
   end
 
   describe '#attributes' do
-    subject { described_class.new(id: 'oo000oo0000') }
+    subject { described_class.new(id: 'bc000df0000') }
     it 'includes the druid' do
-      expect(subject.attributes).to include druid: 'oo000oo0000', druid_tree: 'oo/000/oo/0000'
+      expect(subject.attributes).to include druid: 'bc000df0000', druid_tree: 'bc/000/df/0000'
     end
   end
 

--- a/spec/request/purl_spec.rb
+++ b/spec/request/purl_spec.rb
@@ -19,18 +19,18 @@ RSpec.describe 'PURL API', type: :request do
 
   context 'IIIF v2 requests' do
     it 'redirects manifest.json requests' do
-      get '/1/iiif/manifest.json'
-      expect(response).to redirect_to('/1/iiif/manifest')
+      get '/bc000df0000/iiif/manifest.json'
+      expect(response).to redirect_to('/bc000df0000/iiif/manifest')
     end
 
     it 'redirects canvas json requests' do
-      get '/1/iiif/canvas/whatever.json'
-      expect(response).to redirect_to('/1/iiif/canvas/whatever')
+      get '/bc000df0000/iiif/canvas/whatever.json'
+      expect(response).to redirect_to('/bc000df0000/iiif/canvas/whatever')
     end
 
     it 'redirects annotation json requests' do
-      get '/1/iiif/annotation/whatever.json'
-      expect(response).to redirect_to('/1/iiif/annotation/whatever')
+      get '/bc000df0000/iiif/annotation/whatever.json'
+      expect(response).to redirect_to('/bc000df0000/iiif/annotation/whatever')
     end
 
     it 'responds to OPTIONS requests' do
@@ -62,18 +62,18 @@ RSpec.describe 'PURL API', type: :request do
     end
 
     it 'redirects manifest.json requests' do
-      get '/1/iiif3/manifest.json'
-      expect(response).to redirect_to('/1/iiif3/manifest')
+      get '/bc000df0000/iiif3/manifest.json'
+      expect(response).to redirect_to('/bc000df0000/iiif3/manifest')
     end
 
     it 'redirects canvas json requests' do
-      get '/1/iiif3/canvas/whatever.json'
-      expect(response).to redirect_to('/1/iiif3/canvas/whatever')
+      get '/bc000df0000/iiif3/canvas/whatever.json'
+      expect(response).to redirect_to('/bc000df0000/iiif3/canvas/whatever')
     end
 
     it 'redirects annotation json requests' do
-      get '/1/iiif3/annotation/whatever.json'
-      expect(response).to redirect_to('/1/iiif3/annotation/whatever')
+      get '/bc000df0000/iiif3/annotation/whatever.json'
+      expect(response).to redirect_to('/bc000df0000/iiif3/annotation/whatever')
     end
   end
 


### PR DESCRIPTION
Specifically we're anchoring at the end of string rather than the end of line to prevent appended '%0A'