### PR TITLE
do not show download metrics for collections

### DIFF
--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -111,10 +111,10 @@ class PurlResource
   end
 
   # Show tracked downloads if the object has download permission and is a type that we track
-  # If we can't track downloads (e.g. for WARC), no point in showing the download count
+  # If we can't track downloads (e.g. for WARC),or if it's a collection, no point in showing the download count
   def show_download_metrics?
     (rights.world_downloadable? || rights.stanford_only_downloadable?) &&
-      %w[webarchive-seed webarchive-binary].exclude?(type)
+      %w[webarchive-seed webarchive-binary].exclude?(type) && !collection?
   end
 
   def rights

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -89,5 +89,14 @@ RSpec.describe 'Metrics display', js: true do
         expect(page).not_to have_selector '#download-count'
       end
     end
+
+    # a collection
+    context 'when the object is a collection' do
+      let(:druid) { 'bb631ry3167' }
+
+      it 'does not show the number of downloads' do
+        expect(page).not_to have_selector '#download-count'
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #945 - collection PURLs should never show download metrics

~~HOLD so we can test on stage~~

It works on stage for a collection (not showing) and an item (still showing)

e.g. should **NOT** show on this collection: https://sul-purl-stage.stanford.edu/bc778pm9866 but should still show on this item:  https://sul-purl-stage.stanford.edu/jj986nb3926