### PR TITLE
Consolidate tests that have identical setup

### DIFF
--- a/spec/features/display_purl_page_spec.rb
+++ b/spec/features/display_purl_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Displaying the PURL page' do
   end
 
   context 'book' do
-    it 'works' do
+    it 'displays the page' do
       visit '/bb737zp0787'
       expect(page).to have_content 'The curate of Cumberworth ; and The vicar of Roost : tales'
       expect(page).to have_metadata_section 'Access conditions'
@@ -19,37 +19,25 @@ RSpec.describe 'Displaying the PURL page' do
       expect(page).to have_metadata_section 'Bibliographic information'
       expect(page).to have_metadata_section 'Also listed in'
       expect(page).to have_content 'Vicar of Roost'
-    end
-
-    it 'has a link to the searchworks record' do
-      visit '/bb737zp0787'
       expect(page).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/9616533'
-    end
-
-    it 'has a <link> to the collection' do
-      visit '/bb737zp0787'
       expect(page).to have_css 'link[rel=up][href="http://www.example.com/jt466yc7169"]', visible: :hidden
     end
   end
 
   context 'map' do
-    it 'works' do
+    it 'displays the page' do
       visit '/py305sy7961'
       expect(page).to have_content 'Torrance, Los Angeles Co., Cal., Dec. 1929'
       expect(page).to have_metadata_section 'Access conditions'
       expect(page).to have_metadata_section 'Description'
       expect(page).to have_metadata_section 'Contributors'
       expect(page).to have_metadata_section 'Subjects'
-    end
-
-    it 'adds mailto links in the use and reproduction statement' do
-      visit '/py305sy7961'
       expect(page).to have_link 'brannerlibrary@stanford.edu', href: 'mailto:brannerlibrary@stanford.edu'
     end
   end
 
   context 'etd' do
-    it 'works' do
+    it 'displays the page' do
       visit '/nd387jf5675'
       expect(page).to have_content 'Invariance for perceptual recognition through deep learning'
       expect(page).to have_metadata_section 'Access conditions'
@@ -59,16 +47,12 @@ RSpec.describe 'Displaying the PURL page' do
       expect(page).to have_metadata_section 'Subjects'
       expect(page).to have_metadata_section 'Bibliographic information'
       expect(page).to have_metadata_section 'Also listed in'
-    end
-
-    it 'has a link to the searchworks record' do
-      visit '/nd387jf5675'
       expect(page).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/10734942'
     end
   end
 
   context 'file type' do
-    it 'works' do
+    it 'displays the page' do
       visit '/gx074xz5520'
       expect(page).to have_content 'Minutes, 2006 May 18'
       expect(page).to have_metadata_section 'Access conditions'
@@ -78,31 +62,15 @@ RSpec.describe 'Displaying the PURL page' do
       expect(page).to have_metadata_section 'Subjects'
       expect(page).to have_metadata_section 'Bibliographic information'
       expect(page).to have_metadata_section 'Contact information'
-    end
-
-    it 'lists the collection name' do
-      visit '/gx074xz5520'
       expect(page).to have_content 'Stanford University, Cabinet, Records'
-    end
-
-    it 'lists the preferred citation' do
-      visit '/gx074xz5520'
       expect(page).to have_content 'Stanford University. Cabinet, Stanford University--Administration'
-    end
-
-    it 'shows related items' do
-      visit '/gx074xz5520'
       expect(page).to have_link 'Finding aid', href: 'http://www.oac.cdlib.org/findaid/ark:/13030/kt1h4nf2fr/'
-    end
-
-    it 'provides the archivesref contact information' do
-      visit '/gx074xz5520'
       expect(page).to have_link 'archivesref@stanford.edu', href: 'mailto:archivesref@stanford.edu'
     end
   end
 
   context 'item released to searchworks' do
-    it 'works' do
+    it 'displays the page' do
       visit '/cp088pb1682'
       expect(page).to have_content 'Atari Competition'
       expect(page).to have_metadata_section 'Access conditions'
@@ -112,16 +80,8 @@ RSpec.describe 'Displaying the PURL page' do
       expect(page).to have_metadata_section 'Bibliographic information'
       expect(page).to have_metadata_section 'Collection'
       expect(page).to have_metadata_section 'Also listed in'
-    end
-
-    it 'lists the collection name and links to items in collection' do
-      visit '/cp088pb1682'
       expect(page).to have_content 'Bay Area video arcades : photographs by Ira Nowinski, 1981-1982'
       expect(page).to have_link 'View other items in this collection in SearchWorks', href: 'https://searchworks.stanford.edu/catalog?f[collection][]=a9685083'
-    end
-
-    it 'has a link to the searchworks record' do
-      visit '/cp088pb1682'
       expect(page).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/cp088pb1682'
     end
   end
@@ -135,7 +95,7 @@ RSpec.describe 'Displaying the PURL page' do
   end
 
   context 'revs object' do
-    it 'works' do
+    it 'displays the page' do
       visit '/tx027jv4938'
       expect(page).to have_content 'IMSA 24 Hours of Daytona'
       expect(page).to have_metadata_section 'Access conditions'


### PR DESCRIPTION
This avoids repeating the slow setup time for each scenario