### PR TITLE
Refactor 'View in SearchWorks' & 'View in EarthWorks' links

### DIFF
--- a/app/views/purl/_find_it.html.erb
+++ b/app/views/purl/_find_it.html.erb
@@ -1,22 +1,18 @@
 <% releases = [] %>
 
 <% Settings.releases.each do |dest| %>
-  <% next if dest[:key] == "Searchworks" && document.catalog_key %>
-  
   <% if document.released_to? dest[:key] %>
-    <% releases << link_to(dest[:label], dest[:url] % document.attributes, class: 'su-underline') %>
-  <% end %>
-  <% if dest[:key] == 'EarthWorks' && document.type == 'geo' %>
-    <% releases << link_to(dest[:label], dest[:url] % document.attributes, class: 'su-underline') %>
+    <% if dest[:key] == "Searchworks" && document.catalog_key %>
+      <% key = document.catalog_key %>
+    <% else %>
+      <% key = document.druid %>
+    <% end %>
+    <% releases << link_to(dest[:label], dest[:url] % key, class: 'su-underline') %>
   <% end %>
 <% end %>
 
-<% if document.catalog_key || releases.present? %>
+<% if releases.any? %>
   <%= render SectionComponent.new(label: 'Also listed in') do %>
-    <% if document.catalog_key %>
-      <%= link_to 'View in SearchWorks', "#{Settings.searchworks.url}/view/#{document.catalog_key}", class: 'su-underline' %>
-    <% end %>
-
     <%= releases.to_sentence.html_safe %>
   <% end %>
 <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,10 +34,10 @@ metrics_api_url: "https://sdr-metrics-api-prod.stanford.edu"
 releases:
   - label: "View in SearchWorks"
     key: "Searchworks"
-    url: "https://searchworks.stanford.edu/view/%{druid}"
+    url: "https://searchworks.stanford.edu/view/%s"
   - label: "View in EarthWorks"
-    key: "EarthWorks"
-    url: "https://earthworks.stanford.edu/catalog/stanford-%{druid}"
+    key: "Earthworks"
+    url: "https://earthworks.stanford.edu/catalog/stanford-%s"
 
 searchworks:
   url: "https://searchworks.stanford.edu"

--- a/spec/views/purl/_find_it.html.erb_spec.rb
+++ b/spec/views/purl/_find_it.html.erb_spec.rb
@@ -1,21 +1,64 @@
 require 'rails_helper'
 
 RSpec.describe 'purl/_find_it' do
-  context 'Content-type geo' do
-    let(:purl) { PurlResource.new(id: 'cg357zz0321') }
+  let(:purl) { instance_double(PurlResource, druid: 'cg357zz0321', catalog_key: nil) }
 
-    it 'displays a View in EarthWorks link' do
+  context 'when not released' do
+    before do
+      allow(purl).to receive(:released_to?).with('Searchworks').and_return(false)
+      allow(purl).to receive(:released_to?).with('Earthworks').and_return(false)
+    end
+
+    it 'does not display any links' do
+      render 'purl/find_it', document: purl
+      expect(rendered).to have_no_text 'Also listed in'
+    end
+  end
+
+  context 'when released to SearchWorks' do
+    before do
+      allow(purl).to receive(:released_to?).with('Searchworks').and_return(true)
+      allow(purl).to receive(:released_to?).with('Earthworks').and_return(false)
+    end
+
+    it 'displays a View in SearchWorks link using the druid' do
+      render 'purl/find_it', document: purl
+      expect(rendered).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/cg357zz0321'
+    end
+
+    context 'with a catkey' do
+      before do
+        allow(purl).to receive(:catalog_key).and_return('123456')
+      end
+
+      it 'displays a View in SearchWorks link using the catkey' do
+        render 'purl/find_it', document: purl
+        expect(rendered).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/123456'
+      end
+    end
+  end
+
+  context 'when released to EarthWorks' do
+    before do
+      allow(purl).to receive(:released_to?).with('Searchworks').and_return(false)
+      allow(purl).to receive(:released_to?).with('Earthworks').and_return(true)
+    end
+
+    it 'displays a View in EarthWorks link using the druid' do
       render 'purl/find_it', document: purl
       expect(rendered).to have_link 'View in EarthWorks', href: 'https://earthworks.stanford.edu/catalog/stanford-cg357zz0321'
     end
   end
 
-  context 'Released to SearchWorks' do
-    let(:purl) { PurlResource.new(id: 'bf973rp9392') }
+  context 'when released to both SearchWorks and EarthWorks' do
+    before do
+      allow(purl).to receive(:released_to?).with('Searchworks').and_return(true)
+      allow(purl).to receive(:released_to?).with('Earthworks').and_return(true)
+    end
 
-    it 'displays a View in SearchWorks link' do
+    it 'displays both links' do
       render 'purl/find_it', document: purl
-      expect(rendered).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/bf973rp9392'
+      expect(rendered).to have_text 'View in SearchWorks and View in EarthWorks'
     end
   end
 end


### PR DESCRIPTION
Previously, we prevented the rendering of EarthWorks view links
for all content that didn't have the geo content type. We now have
a lot of scanned maps in EarthWorks that deserve to be linked to
from Purl.

The logic for deciding how and when to render these links was also
convoluted, so this PRs simplifies it somewhat and expands the
tests.
