### PR TITLE
Revert "Refactor 'View in SearchWorks' & 'View in EarthWorks' links"

### DIFF
--- a/app/views/purl/_find_it.html.erb
+++ b/app/views/purl/_find_it.html.erb
@@ -1,18 +1,22 @@
 <% releases = [] %>
 
 <% Settings.releases.each do |dest| %>
+  <% next if dest[:key] == "Searchworks" && document.catalog_key %>
+  
   <% if document.released_to? dest[:key] %>
-    <% if dest[:key] == "Searchworks" && document.catalog_key %>
-      <% key = document.catalog_key %>
-    <% else %>
-      <% key = document.druid %>
-    <% end %>
-    <% releases << link_to(dest[:label], dest[:url] % key, class: 'su-underline') %>
+    <% releases << link_to(dest[:label], dest[:url] % document.attributes, class: 'su-underline') %>
+  <% end %>
+  <% if dest[:key] == 'EarthWorks' && document.type == 'geo' %>
+    <% releases << link_to(dest[:label], dest[:url] % document.attributes, class: 'su-underline') %>
   <% end %>
 <% end %>
 
-<% if releases.any? %>
+<% if document.catalog_key || releases.present? %>
   <%= render SectionComponent.new(label: 'Also listed in') do %>
+    <% if document.catalog_key %>
+      <%= link_to 'View in SearchWorks', "#{Settings.searchworks.url}/view/#{document.catalog_key}", class: 'su-underline' %>
+    <% end %>
+
     <%= releases.to_sentence.html_safe %>
   <% end %>
 <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,10 +34,10 @@ metrics_api_url: "https://sdr-metrics-api-prod.stanford.edu"
 releases:
   - label: "View in SearchWorks"
     key: "Searchworks"
-    url: "https://searchworks.stanford.edu/view/%s"
+    url: "https://searchworks.stanford.edu/view/%{druid}"
   - label: "View in EarthWorks"
-    key: "Earthworks"
-    url: "https://earthworks.stanford.edu/catalog/stanford-%s"
+    key: "EarthWorks"
+    url: "https://earthworks.stanford.edu/catalog/stanford-%{druid}"
 
 searchworks:
   url: "https://searchworks.stanford.edu"

--- a/spec/views/purl/_find_it.html.erb_spec.rb
+++ b/spec/views/purl/_find_it.html.erb_spec.rb
@@ -1,64 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe 'purl/_find_it' do
-  let(:purl) { instance_double(PurlResource, druid: 'cg357zz0321', catalog_key: nil) }
+  context 'Content-type geo' do
+    let(:purl) { PurlResource.new(id: 'cg357zz0321') }
 
-  context 'when not released' do
-    before do
-      allow(purl).to receive(:released_to?).with('Searchworks').and_return(false)
-      allow(purl).to receive(:released_to?).with('Earthworks').and_return(false)
-    end
-
-    it 'does not display any links' do
-      render 'purl/find_it', document: purl
-      expect(rendered).to have_no_text 'Also listed in'
-    end
-  end
-
-  context 'when released to SearchWorks' do
-    before do
-      allow(purl).to receive(:released_to?).with('Searchworks').and_return(true)
-      allow(purl).to receive(:released_to?).with('Earthworks').and_return(false)
-    end
-
-    it 'displays a View in SearchWorks link using the druid' do
-      render 'purl/find_it', document: purl
-      expect(rendered).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/cg357zz0321'
-    end
-
-    context 'with a catkey' do
-      before do
-        allow(purl).to receive(:catalog_key).and_return('123456')
-      end
-
-      it 'displays a View in SearchWorks link using the catkey' do
-        render 'purl/find_it', document: purl
-        expect(rendered).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/123456'
-      end
-    end
-  end
-
-  context 'when released to EarthWorks' do
-    before do
-      allow(purl).to receive(:released_to?).with('Searchworks').and_return(false)
-      allow(purl).to receive(:released_to?).with('Earthworks').and_return(true)
-    end
-
-    it 'displays a View in EarthWorks link using the druid' do
+    it 'displays a View in EarthWorks link' do
       render 'purl/find_it', document: purl
       expect(rendered).to have_link 'View in EarthWorks', href: 'https://earthworks.stanford.edu/catalog/stanford-cg357zz0321'
     end
   end
 
-  context 'when released to both SearchWorks and EarthWorks' do
-    before do
-      allow(purl).to receive(:released_to?).with('Searchworks').and_return(true)
-      allow(purl).to receive(:released_to?).with('Earthworks').and_return(true)
-    end
+  context 'Released to SearchWorks' do
+    let(:purl) { PurlResource.new(id: 'bf973rp9392') }
 
-    it 'displays both links' do
+    it 'displays a View in SearchWorks link' do
       render 'purl/find_it', document: purl
-      expect(rendered).to have_text 'View in SearchWorks and View in EarthWorks'
+      expect(rendered).to have_link 'View in SearchWorks', href: 'https://searchworks.stanford.edu/view/bf973rp9392'
     end
   end
 end


### PR DESCRIPTION
This reverts commit 13b32a555f24bcd4b60d213527786aabb9ca0b80.