### PR TITLE
Prefer locally stored metadata over API calls to external systems.

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -30,6 +30,10 @@ class PurlController < ApplicationController
         end
       end
 
+      format.meta_json do
+        render json: @purl.meta_json
+      end
+
       format.json do
         if @purl.cocina?
           render json: @purl.cocina_body

--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -54,10 +54,16 @@ class PurlResource
     @public_xml ||= PublicXml.new(public_xml_document)
   end
 
+  def meta_json
+    @meta_json ||= JSON.parse(meta_json_body) if meta_json_body.present?
+  end
+
+  # @deprecated
   def purl_fetcher_json
     @purl_fetcher_json ||= purl_fetcher_conn.get("/purls/#{id}").body
   end
 
+  # @deprecated
   def purl_fetcher_conn
     Faraday.new(url: Settings.purl_fetcher.url) do |builder|
       builder.response :json
@@ -80,7 +86,7 @@ class PurlResource
 
   # Can be crawled / indexed by a crawler, e.g. Googlebot
   def crawlable?
-    purl_fetcher_json.fetch('true_targets').include?('PURL sitemap')
+    (meta_json || purl_fetcher_json).fetch('true_targets').include?('PURL sitemap')
   rescue StandardError => e
     Honeybadger.notify(e)
     false # ensure that purl-fetcher being down doesn't prevent the page from drawing
@@ -300,6 +306,16 @@ class PurlResource
 
     def public_xml_body
       public_xml_resource.body if public_xml_resource.success?
+    end
+
+    def meta_json_resource
+      @meta_json_resource ||= cache_resource(:meta) do
+        fetch_resource(:meta, Settings.purl_resource.meta)
+      end
+    end
+
+    def meta_json_body
+      meta_json_resource.body if meta_json_resource.success?
     end
 
     def public_xml?

--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -54,8 +54,8 @@ class PurlResource
     @public_xml ||= PublicXml.new(public_xml_document)
   end
 
-  def public_json
-    @public_json ||= purl_fetcher_conn.get("/purls/#{id}").body
+  def purl_fetcher_json
+    @purl_fetcher_json ||= purl_fetcher_conn.get("/purls/#{id}").body
   end
 
   def purl_fetcher_conn
@@ -80,7 +80,7 @@ class PurlResource
 
   # Can be crawled / indexed by a crawler, e.g. Googlebot
   def crawlable?
-    public_json.fetch('true_targets').include?('PURL sitemap')
+    purl_fetcher_json.fetch('true_targets').include?('PURL sitemap')
   rescue StandardError => e
     Honeybadger.notify(e)
     false # ensure that purl-fetcher being down doesn't prevent the page from drawing

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -4,3 +4,4 @@
 # Mime::Type.register "text/richtext", :rtf
 
 Mime::Type.register 'application/xml', :mods
+Mime::Type.register 'application/meta+json', :meta_json

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,7 @@ resource_cache:
 purl_resource:
   public_xml: "https://purl.stanford.edu/%{druid}.xml"
   cocina: "https://purl.stanford.edu/%{druid}.json"
+  meta: "https://purl.stanford.edu/%{druid}.meta_json"
 
 embed:
   url: "https://purl.stanford.edu/%{druid}"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,6 +2,10 @@ document_cache_root: "<%= File.join(Rails.root, "spec", "fixtures", "document_ca
 purl_resource:
   public_xml: "<%= File.join(Rails.root, "spec", "fixtures", "document_cache") %>/%{druid_tree}/public"
   cocina: "<%= File.join(Rails.root, "spec", "fixtures", "document_cache") %>/%{druid_tree}/cocina.json"
+  meta: "<%= File.join(Rails.root, "spec", "fixtures", "document_cache") %>/%{druid_tree}/meta.json"
 
 content_search:
   url: "http://example.com/content_search/%{druid}/search"
+
+resource_cache:
+  enabled: false

--- a/spec/model/purl_resource_spec.rb
+++ b/spec/model/purl_resource_spec.rb
@@ -243,21 +243,42 @@ RSpec.describe PurlResource do
     subject { instance.crawlable? }
     let(:druid) { 'druid:kn112rm5773' }
 
-    before do
-      stub_request(:get, 'https://purl-fetcher-stage.stanford.edu/purls/druid:kn112rm5773')
-        .to_return(status: 200, body: "{\"true_targets\": #{true_targets}}", headers: { 'content-type' => 'application/json' })
+    context 'with a meta.json file in the object path' do
+      before do
+        allow(DocumentCacheResource).to receive(:new).and_return(instance_double(DocumentCacheResource, body: "{\"true_targets\": #{true_targets} }",
+                                                                                                        success?: true))
+      end
+
+      context 'when resource has a sitemap target' do
+        let(:true_targets) { ['PURL sitemap'] }
+
+        it { is_expected.to be true }
+      end
+
+      context 'when resource has a no sitemap' do
+        let(:true_targets) { ['Searchworks'] }
+
+        it { is_expected.to be false }
+      end
     end
 
-    context 'when resource has a sitemap target' do
-      let(:true_targets) { ['PURL sitemap'] }
+    context 'without a meta.json file in the object path' do
+      before do
+        stub_request(:get, 'https://purl-fetcher-stage.stanford.edu/purls/druid:kn112rm5773')
+          .to_return(status: 200, body: "{\"true_targets\": #{true_targets}}", headers: { 'content-type' => 'application/json' })
+      end
 
-      it { is_expected.to be true }
-    end
+      context 'when resource has a sitemap target' do
+        let(:true_targets) { ['PURL sitemap'] }
 
-    context 'when resource has a no sitemap' do
-      let(:true_targets) { ['Searchworks'] }
+        it { is_expected.to be true }
+      end
 
-      it { is_expected.to be false }
+      context 'when resource has a no sitemap' do
+        let(:true_targets) { ['Searchworks'] }
+
+        it { is_expected.to be false }
+      end
     end
   end
 


### PR DESCRIPTION
The PURL architecture has traditionally used files on the local file system to drive all application functionality. Making run-time API calls out to external systems makes it harder to develop + debug, obscures the source of truth, and doesn't seem like it provides a lot of value for the additional complexity.

Instead of calling out to purl-fetcher, purl-fetcher could just write the unversioned data to PURL 🤷‍♂️ 

See https://github.com/sul-dlss/purl-fetcher/pull/750.