### PR TITLE
Add a canonnical link for the benifit of crawlers

### DIFF
--- a/app/views/purl/show.html.erb
+++ b/app/views/purl/show.html.erb
@@ -6,6 +6,7 @@
     <%= tag :link, rel: "alternate", title: "oEmbed Profile", type: 'application/json+oembed', href: oembed_url_template.expand(format: 'json', url: embeddable_url(@purl.druid)) %>
     <%= tag :link, rel: "alternate", title: "oEmbed Profile", type: 'application/xml+oembed', href: oembed_url_template.expand(format: 'xml', url: embeddable_url(@purl.druid)) %>
   <% end %>
+  <%= tag :link, rel: "canonical", href: purl_url(@purl) %>
   <%= tag :link, rel: "alternate", title: "MODS XML", type: 'application/xml', href: purl_url(@purl, format: 'mods') if @purl.mods? %>
   <%= tag :link, rel: "alternate", title: "IIIF Manifest", type: 'application/json', href: manifest_iiif_purl_url(@purl) %>
   <%= tag :link, rel: "up", href: purl_url(@purl.containing_collections.first) if @purl.containing_collections.present? %>


### PR DESCRIPTION
See https://support.google.com/webmasters/answer/7440203\#duplicate_page_without_canonical_tag This allows Google to know that this url:
https://purl.stanford.edu/kh752sm9123\?sm_guid\=NTU1NzgyfDYzMDE1OTM2fC0xfGppbUBha2ZhbWlseS5vcmd8NTY4OTI4MXx8MHwwfDE2MzI1MzEyNXwxMDg2fDB8MHx8NTQ3NzI2fDA1 should be added to the index without all the extra parameters