### PR TITLE
Remove support for the legacy meta.json format

### DIFF
--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -41,24 +41,15 @@ class PurlResource
 
   # Can be crawled / indexed by a crawler, e.g. Googlebot
   def crawlable?
-    return meta_json['sitemap'] if meta_json.key?('sitemap')
-
-    # This is for handling the older format of meta.json
-    true_targets.include?('PURL sitemap')
+    meta_json.fetch('sitemap')
   end
 
   def released_to_searchworks?
-    return meta_json['searchworks'] if meta_json.key?('searchworks')
-
-    # This is for handling the older format of meta.json
-    true_targets.include?('Searchworks')
+    meta_json.fetch('searchworks')
   end
 
   def released_to_earthworks?
-    return meta_json['earthworks'] if meta_json.key?('earthworks')
-
-    # This is for handling the older format of meta.json
-    true_targets.include?('Earthworks')
+    meta_json.fetch('earthworks')
   end
 
   def metrics
@@ -76,10 +67,6 @@ class PurlResource
 
   def meta_json
     @meta_json ||= JSON.parse(meta_json_body) if meta_json_body.present?
-  end
-
-  def true_targets
-    meta_json.fetch('true_targets')
   end
 
   def metrics_service

--- a/spec/fixtures/document_cache/sk/882/gx/0113/meta.json
+++ b/spec/fixtures/document_cache/sk/882/gx/0113/meta.json
@@ -1,1 +1,1 @@
-{ "true_targets": ["Searchworks"] }
+{ "sitemap": false, "searchworks": true, "earthworks": false }

--- a/spec/fixtures/document_cache/yb/533/nc/1884/meta.json
+++ b/spec/fixtures/document_cache/yb/533/nc/1884/meta.json
@@ -1,1 +1,1 @@
-{ "true_targets": ["Searchworks"] }
+{ "sitemap": false, "searchworks": true, "earthworks": false }

--- a/spec/model/purl_resource_spec.rb
+++ b/spec/model/purl_resource_spec.rb
@@ -28,18 +28,18 @@ RSpec.describe PurlResource do
     context 'with a meta.json file in the object path' do
       before do
         allow(Rails.cache).to receive(:fetch).and_yield
-        allow(DocumentCacheResource).to receive(:new).and_return(instance_double(DocumentCacheResource, body: "{\"true_targets\": #{true_targets} }",
+        allow(DocumentCacheResource).to receive(:new).and_return(instance_double(DocumentCacheResource, body:,
                                                                                                         success?: true))
       end
 
       context 'when resource has a sitemap target' do
-        let(:true_targets) { ['PURL sitemap'] }
+        let(:body) { '{"sitemap":true}' }
 
         it { is_expected.to be true }
       end
 
       context 'when resource has a no sitemap' do
-        let(:true_targets) { ['Searchworks'] }
+        let(:body) { '{"sitemap":false}' }
 
         it { is_expected.to be false }
       end


### PR DESCRIPTION
all objects have been migrated to the new format