### PR TITLE
Prevent ActionView::MissingTemplate when unknown format is passed

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -73,7 +73,7 @@ class PurlController < ApplicationController
   end
 
   def missing_file
-    render '/errors/missing_file', status: :not_found
+    render '/errors/missing_file', status: :not_found, formats: [:html]
   end
 
   def fix_etag_header

--- a/spec/request/purl_spec.rb
+++ b/spec/request/purl_spec.rb
@@ -1,7 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe 'PURL API', type: :request do
-  context 'PURL page' do
+  describe 'root page' do
+    context 'for an unknown format' do
+      it 'returns 404 page' do
+        get '/?format=xml'
+        expect(response).to have_http_status(:not_found)
+        expect(response.body).to include "The page you were looking for doesn't exist."
+      end
+    end
+  end
+
+  describe 'PURL page' do
     it 'responds to OPTIONS requests' do
       options '/bb157hs6068'
       expect(response).to be_successful


### PR DESCRIPTION
This typically is triggered by scanners looking for PHP vulnerabilities