### PR TITLE
Don't use deprecated Google sitemap ping

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -28,5 +28,5 @@ job_type :rake_hb, 'cd :path && :environment_variable=:environment bundle exec r
 
 every :month, roles: [:cron] do
   set :check_in, Settings.honeybadger_checkins.sitemap
-  rake_hb "sitemap:refresh"
+  rake_hb "sitemap:refresh:no_ping" # pinging Google is deprecated
 end


### PR DESCRIPTION
The current `sitemap:refresh` task generates a deprecation warning from Google. (See: https://github.com/kjvarga/sitemap_generator/issues/432). 

This issue hasn't been addressed yet, so use the `:no_ping` option in the task. There are no other search engines that were being pinged. 

