### PR TITLE
Retreive meta.json from stacks for versioned objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,22 @@ By default, local development will use production XML from PURL, so that you can
 2. Create druid tree folders (e.g. `document_cache/xk/755/gc/8675`, just like they would be on stacks) and put `mods` and `public` XML files there.  You can get examples from the `spec/fixtures/document_cache` or production PURL.  Note that the `document_cache` folder is already in `.gitignore` so any content copied there will not be added to git.
 3. Create a `config/settings.local.yml` file (if you don't have one already) and add the following:
 
+Unversioned object:
 ```
 # Comment out for lookup to production PURL
 purl_resource:
   public_xml: "<%= File.join(Rails.root, "document_cache") %>/%{druid_tree}/public"
   cocina: "<%= File.join(Rails.root, "document_cache") %>/%{druid_tree}/cocina.json"
+  meta: "<%= File.join(Rails.root, "document_cache") %>/%{druid_tree}/meta.json"
+```
+
+Versioned object:
+```
+# Comment out for lookup to production PURL
+purl_resource:
+  public_xml: "<%= File.join(Rails.root, "document_cache") %>/%{druid_tree}/%{druid}/versions/public.%{version_id}.xml"
+  cocina: "<%= File.join(Rails.root, "document_cache") %>/%{druid_tree}/%{druid}/versions/cocina.%{version_id}.json"
+  meta: "<%= File.join(Rails.root, "document_cache") %>/%{druid_tree}/%{druid}/versions/meta.json"
 ```
 
 If you leave this config uncommented, the local app will find content in the local document_cache.  If you comment it out, it will revert to the default behavior (look up content on PURL).

--- a/app/services/resource_retriever.rb
+++ b/app/services/resource_retriever.rb
@@ -76,6 +76,12 @@ class ResourceRetriever
     Settings.purl_resource.public_xml
   end
 
+  def meta_json_path
+    return Settings.purl_resource.versioned.meta if versioned_layout?
+
+    Settings.purl_resource.meta
+  end
+
   def cocina_path
     return Settings.purl_resource.versioned.cocina if versioned_layout?
 
@@ -90,7 +96,7 @@ class ResourceRetriever
 
   def meta_json_resource
     @meta_json_resource ||= cache_resource(:meta) do
-      fetch_resource(:meta, Settings.purl_resource.meta)
+      fetch_resource(:meta, meta_json_path)
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,7 @@ purl_resource:
   versioned:
     public_xml: "https://purl.stanford.edu/%{druid}/version/%{version_id}.xml"
     cocina: "https://purl.stanford.edu/%{druid}/version/%{version_id}.json"
+    meta: "https://purl.stanford.edu/%{druid}.meta_json" # versioned meta is not supported
 
 embed:
   url: "https://purl.stanford.edu/%{druid}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,7 +24,7 @@ purl_resource:
   versioned:
     public_xml: "https://purl.stanford.edu/%{druid}/version/%{version_id}.xml"
     cocina: "https://purl.stanford.edu/%{druid}/version/%{version_id}.json"
-    meta: "https://purl.stanford.edu/%{druid}.meta_json" # versioned meta is not supported
+    meta: "https://purl.stanford.edu/%{druid}/meta.json" # versioned meta is not supported
 
 embed:
   url: "https://purl.stanford.edu/%{druid}"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,6 +6,7 @@ purl_resource:
   versioned:
     public_xml: "%{root_path}/%{druid_tree}/%{druid}/versions/public.%{version_id}.xml"
     cocina: "%{root_path}/%{druid_tree}/%{druid}/versions/cocina.%{version_id}.json"
+    meta: "%{root_path}/%{druid_tree}/meta.json"
 
 stacks:
   version_manifest_path: "%{root_path}/%{druid_tree}/%{druid}/versions/versions.json"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,7 +6,7 @@ purl_resource:
   versioned:
     public_xml: "%{root_path}/%{druid_tree}/%{druid}/versions/public.%{version_id}.xml"
     cocina: "%{root_path}/%{druid_tree}/%{druid}/versions/cocina.%{version_id}.json"
-    meta: "%{root_path}/%{druid_tree}/meta.json"
+    meta: "%{root_path}/%{druid_tree}/%{druid}/versions/meta.json"
 
 stacks:
   version_manifest_path: "%{root_path}/%{druid_tree}/%{druid}/versions/versions.json"

--- a/spec/fixtures/document_cache/wp/335/yr/5649/wp335yr5649/versions/meta.json
+++ b/spec/fixtures/document_cache/wp/335/yr/5649/wp335yr5649/versions/meta.json
@@ -1,0 +1,1 @@
+{ "searchworks": false, "earthworks": false, "sitemap": false }


### PR DESCRIPTION
Fixes #1083 

When an object is versioned, retrieve meta.json from the stacks path. Corresponding shared_configs PRs:

https://github.com/sul-dlss/shared_configs/pull/2228 (stage)
https://github.com/sul-dlss/shared_configs/pull/2229 (uat)
https://github.com/sul-dlss/shared_configs/pull/2230 (prod)
