### PR TITLE
Render tombstone page for withdrawn versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 
 coverage
 config/honeybadger.yml
-document_cache/*
+/document_cache
 .byebug_history
 .ruby-gemset
 .ruby-version

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The defaults in `config/settings.yml` should work on a locally run installation.
 By default, local development will use production XML from PURL, so that you can hit any valid object when testing locally.  If you want to use local XML for testing, which can be useful if you want to alter data and see the results, do this:
 
 1. Create a local "document_cache" folder in the root of the PURL rails app on your laptop.
-2. Create druid tree folders (e.g. `document_cache/xk/755/gc/8675`, just like they would be on stacks) and put `mods` and `public` XML files there.  You can get examples from the `spec/fixtures/document_cache` or production PURL.  Note that the `document_cache` folder is already in `.gitignore` so any content copied there will not be added to git.
+2. Create druid tree folders (e.g. `document_cache/xk/755/gc/8675`, just like they would be on stacks) and put `mods` and `public` XML files there.  You can get examples from the `spec/fixtures/document_cache` or production PURL. Note that the `document_cache` folder is already in `.gitignore` so any content copied there will not be added to git. An easy solution would be to run `ln -s spec/fixtures/document_cache .`.
 3. Create a `config/settings.local.yml` file (if you don't have one already) and add the following:
 
 ```

--- a/app/views/purl/show.html.erb
+++ b/app/views/purl/show.html.erb
@@ -48,37 +48,40 @@ end
     <h1 class="py-2"><%= @version.title %></h1>
   </div>
 </div>
-<% if @version.embeddable? %>
-<div class="upper-record-metadata row">
-  <div class="col-md-12">
-    <%= render 'embed' %>
+
+<% unless @version.withdrawn? %>
+  <% if @version.embeddable? %>
+    <div class="upper-record-metadata row">
+      <div class="col-md-12">
+        <%= render 'embed' %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="record-metadata row gx-5">
+    <div class="record-sections col-lg-8">
+      <% if @version.mods? %>
+        <%= render "mods_abstract_contents", document: @version %>
+        <%= render ModsDescriptionComponent.new(document: @version) %>
+        <%= render ModsContributorsComponent.new(document: @version) %>
+        <%= render SubjectComponent.new(document: @version) %>
+        <%= render BibliographicComponent.new(document: @version) %>
+      <% end %>
+    </div>
+    <div class="record-sections col-lg-4">
+      <%= render AccessComponent.new(document: @version) %>
+      <%= render 'mods_citation', document: @version %>
+      <%= render "collection", document: @version %>
+      <%= render "collection_items", document: @version if @purl.released_to_searchworks? %>
+      <%= render VersionsComponent.new(purl: @purl, version: @version) if params[:version_feature] %>
+      <%= render "mods_contact", document: @version %>
+      <%= render "find_it", document: @purl, catalog_key: @version.catalog_key %>
+
+      <% if @version.embeddable? || @version.show_download_metrics? || @version.doi.present? %>
+        <turbo-frame id="metrics-frame" src="<%= purl_metrics_path @purl %>">
+          <p>Loading usage metrics...</p>
+        </turbo-frame>
+      <% end %>
+    </div>
   </div>
-</div>
 <% end %>
-
-<div class="record-metadata row gx-5">
-  <div class="record-sections col-lg-8">
-    <% if @version.mods? %>
-      <%= render "mods_abstract_contents", document: @version %>
-      <%= render ModsDescriptionComponent.new(document: @version) %>
-      <%= render ModsContributorsComponent.new(document: @version) %>
-      <%= render SubjectComponent.new(document: @version) %>
-      <%= render BibliographicComponent.new(document: @version) %>
-    <% end %>
-  </div>
-  <div class="record-sections col-lg-4">
-    <%= render AccessComponent.new(document: @version) %>
-    <%= render 'mods_citation', document: @version %>
-    <%= render "collection", document: @version %>
-    <%= render "collection_items", document: @version if @purl.released_to_searchworks? %>
-    <%= render VersionsComponent.new(purl: @purl, version: @version) if params[:version_feature] %>
-    <%= render "mods_contact", document: @version %>
-    <%= render "find_it", document: @purl, catalog_key: @version.catalog_key %>
-
-    <% if @version.embeddable? || @version.show_download_metrics? || @version.doi.present? %>
-      <turbo-frame id="metrics-frame" src="<%= purl_metrics_path @purl %>">
-        <p>Loading usage metrics...</p>
-      </turbo-frame>
-    <% end %>
-  </div>
-</div>

--- a/spec/requests/purl_spec.rb
+++ b/spec/requests/purl_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe 'PURL API' do
           'Compressed Sensing Phase Transitions of Gaussian Random Matrices.&quot; -- VERSION 3'
         )
         expect(response.body).not_to include('A newer version of this item is available')
+        expect(response.body).to have_css('div.upper-record-metadata')
+        expect(response.body).to have_css('div.record-metadata')
       end
 
       context 'with legit version specified' do
@@ -70,6 +72,27 @@ RSpec.describe 'PURL API' do
             'Compressed Sensing Phase Transitions of Gaussian Random Matrices.&quot; -- VERSION 1'
           )
           expect(response.body).to include('A newer version of this item is available')
+          expect(response.body).to have_css('div.upper-record-metadata')
+          expect(response.body).to have_css('div.record-metadata')
+        end
+      end
+
+      context 'with withdrawn version specified' do
+        it 'returns the PURL page of the requested version with only tombstone information' do
+          get '/wp335yr5649/v2'
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include(
+            'Code and Data supplement to &quot;Deterministic Matrices Matching the ' \
+            'Compressed Sensing Phase Transitions of Gaussian Random Matrices.&quot; -- VERSION 2'
+          )
+          expect(response.body).not_to include('A newer version of this item is available')
+          expect(response.body).to include('This version has been withdrawn')
+          expect(response.body).to include('Please visit <a href="http://www.example.com/wp335yr5649">http://www.example.com/wp335yr5649</a> ' \
+                                           'to view the other versions of this item.')
+          expect(response.body).not_to include('Description')
+          expect(response.body).not_to include('Preferred citation')
+          expect(response.body).to have_no_css('div.upper-record-metadata')
+          expect(response.body).to have_no_css('div.record-metadata')
         end
       end
 


### PR DESCRIPTION
Fixes #1042

- **Simplify local dev document cache setup**
- **Render tombstone page for withdrawn versions**

# Screenshot

Note: re-styling and improving the a11y of the flash banner is already part of https://github.com/sul-dlss/purl/issues/1079, so it's not included in this PR.

![Screenshot from 2024-07-29 13-29-16](https://github.com/user-attachments/assets/1bcedcb0-46df-4c90-ad7e-7c2f94da1967)

