### PR TITLE
The .su-underline class moved into the component-library

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,12 +12,6 @@
   --bs-table-border-color: var(--bs-gray-500);
 }
 
-.su-underline {
-  --underline-color: var(--bs-gray-500);
-  --bs-link-hover-decoration: var(--bs-link-decoration);
-  --bs-link-decoration: underline dotted var(--underline-color) 1px;
-}
-
 #main-container {
   /* keep the not available items with sufficent height. See db586ns4974 */
   min-height: calc(100vh - 323px);


### PR DESCRIPTION
So we don't need a second copy of it.