### PR TITLE
remove unused code

### DIFF
--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -8,20 +8,6 @@ class PurlResource
 
   class DruidNotValid < StandardError; end
 
-  def self.all
-    return [] unless Settings.document_cache_root
-    return to_enum(:all) unless block_given?
-
-    Find.find(Settings.document_cache_root) do |path|
-      next unless path.ends_with?('public')
-
-      druid = Dor::Util.druid_from_pair_tree(path)
-      next unless druid
-
-      yield PurlResource.find(druid)
-    end
-  end
-
   def self.find(id)
     raise DruidNotValid, id unless Dor::Util.validate_druid(id)
 

--- a/lib/dor/util.rb
+++ b/lib/dor/util.rb
@@ -4,8 +4,6 @@ module Dor
   # constants
   DRUID_REGEX = /\A([b-df-hjkmnp-tv-z]{2})([0-9]{3})([b-df-hjkmnp-tv-z]{2})([0-9]{4})\z/i
 
-  PAIRTREE_REGEX = %r{/([a-z]{2})/(\d{3})/([a-z]{2})/(\d{4})}
-
   class Util
     #
     # This method validates the given id to be of the following format:
@@ -25,12 +23,6 @@ module Dor
       match = pid.match(DRUID_REGEX)
 
       File.join(match[1], match[2], match[3], match[4]) if match
-    end
-
-    def self.druid_from_pair_tree(path)
-      return unless (match = path.match(PAIRTREE_REGEX))
-
-      match[1] + match[2] + match[3] + match[4]
     end
   end
 end


### PR DESCRIPTION
This was to support sitemaps from the filesystem, but we've found it's much faster to do this from purl-fetcher