### PR TITLE
Don't include version in sul-embed iframe URL when purl is base url

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,10 +34,10 @@ module ApplicationHelper
   def embeddable_url(druid, version_id = nil)
     if Settings.embed.url
       (Settings.embed.url % { druid: }).tap do |embed_url|
-        return "#{embed_url}/version/#{version_id}" if version_id.present?
+        return "#{embed_url}/version/#{version_id}" if version_id.present? && request.path == version_purl_path(druid, version_id)
       end
     else
-      version_id.present? ? versioned_purl_url(druid, version_id) : purl_url(druid)
+      version_id.present? ? version_purl_url(druid, version_id) : purl_url(druid)
     end
   end
 

--- a/spec/views/purl/_embed.html.erb_spec.rb
+++ b/spec/views/purl/_embed.html.erb_spec.rb
@@ -3,41 +3,69 @@ require 'rails_helper'
 RSpec.describe 'purl/_embed' do
   before { assign(:purl, purl) }
 
-  let(:purl) { PurlResource.new(id: 'xyz') }
+  let(:purl) { PurlResource.new(id: 'bf973rp9392') }
 
   it 'displays a purl embed viewer' do
     render
     expect(rendered).to have_css '.purl-embed-viewer'
     embed = Nokogiri::HTML(rendered).css('.purl-embed-viewer')
     expect(embed.attr('data-oembed-provider').to_s).to eq 'https://embed.stanford.edu/embed.json?hide_title=true&hide_metadata=true'
-    expect(embed.attr('href').to_s).to eq('https://purl.stanford.edu/xyz')
+    expect(embed.attr('href').to_s).to eq('https://purl.stanford.edu/bf973rp9392')
   end
 
   it 'displays a non-javascript fallback' do
     render
     expect(rendered).to have_css 'noscript iframe'
     iframe = Nokogiri::HTML(rendered).xpath('//iframe')
-    expect(iframe.attr('src').to_s).to eq 'https://embed.stanford.edu/iframe/?url=https%3A%2F%2Fpurl.stanford.edu%2Fxyz'
+    expect(iframe.attr('src').to_s).to eq 'https://embed.stanford.edu/iframe/?url=https%3A%2F%2Fpurl.stanford.edu%2Fbf973rp9392'
   end
 
   context 'when a version is specified' do
-    before { assign(:version, version) }
+    let(:version) { PurlVersion.new(id: 'bf973rp9392', head: true, state: 'available', version_id: 2) }
 
-    let(:version) { PurlVersion.new(id: 'xyz', head: true, state: 'available', version_id: 2) }
+    before do
+      assign(:version, version)
+      allow_any_instance_of(ActionDispatch::Request).to receive(:path).and_return('/bf973rp9392/version/2') # rubocop:disable RSpec/AnyInstance
+      allow(purl).to receive(:version).with(2).and_return(version)
+    end
 
-    it 'displays a purl embed viewer' do
+    it 'displays a purl embed viewer with the version' do
       render
       expect(rendered).to have_css '.purl-embed-viewer'
       embed = Nokogiri::HTML(rendered).css('.purl-embed-viewer')
       expect(embed.attr('data-oembed-provider').to_s).to eq 'https://embed.stanford.edu/embed.json?hide_title=true&hide_metadata=true'
-      expect(embed.attr('href').to_s).to eq('https://purl.stanford.edu/xyz/version/2')
+      expect(embed.attr('href').to_s).to eq('https://purl.stanford.edu/bf973rp9392/version/2')
     end
 
     it 'displays a non-javascript fallback' do
       render
       expect(rendered).to have_css 'noscript iframe'
       iframe = Nokogiri::HTML(rendered).xpath('//iframe')
-      expect(iframe.attr('src').to_s).to eq 'https://embed.stanford.edu/iframe/?url=https%3A%2F%2Fpurl.stanford.edu%2Fxyz%2Fversion%2F2'
+      expect(iframe.attr('src').to_s).to eq 'https://embed.stanford.edu/iframe/?url=https%3A%2F%2Fpurl.stanford.edu%2Fbf973rp9392%2Fversion%2F2'
+    end
+  end
+
+  context 'when a version is not specified' do
+    let(:version) { PurlVersion.new(id: 'bf973rp9392', head: true, state: 'available', version_id: 1) }
+
+    before do
+      allow(purl).to receive(:version).and_return(version)
+      allow_any_instance_of(ActionDispatch::Request).to receive(:path).and_return('/bf973rp9392') # rubocop:disable RSpec/AnyInstance
+    end
+
+    it 'does not display a purl embed viewer with a version' do
+      render
+      expect(rendered).to have_css '.purl-embed-viewer'
+      embed = Nokogiri::HTML(rendered).css('.purl-embed-viewer')
+      expect(embed.attr('data-oembed-provider').to_s).to eq 'https://embed.stanford.edu/embed.json?hide_title=true&hide_metadata=true'
+      expect(embed.attr('href').to_s).to eq('https://purl.stanford.edu/bf973rp9392')
+    end
+
+    it 'displays a non-javascript fallback' do
+      render
+      expect(rendered).to have_css 'noscript iframe'
+      iframe = Nokogiri::HTML(rendered).xpath('//iframe')
+      expect(iframe.attr('src').to_s).to eq 'https://embed.stanford.edu/iframe/?url=https%3A%2F%2Fpurl.stanford.edu%2Fbf973rp9392'
     end
   end
 end


### PR DESCRIPTION
Resolves #1135.

Updates embed iframe URL and embed code to use base URL when head version. 

Andrew tested and approved. 


