### PR TITLE
Fix display of version identifiers

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -58,7 +58,7 @@
       }
 
       tbody {
-        tr:not(:first-of-type) th {
+        tr:not(:first-of-type) th:not(.version-identifier) {
           /* Visibility hidden doesn't work here because it also hides the border */
           font-size: 0;
         }


### PR DESCRIPTION
The prior commit removed a surrounding `<tbody>` element around each version row component which caused a CSS rule preventing display of multiple `<th>` elements in the same table. We want this CSS behavior to prevent repetitive metadata label display. The fix here is to fine-tune the CSS rule such that it ignores the version identifier table header element.
