### PR TITLE
Add link to old version banner

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -118,7 +118,8 @@ class PurlController < ApplicationController
       flash.now[:alert] = '<b>This version has been withdrawn</b><br>' \
                           "Please visit #{view_context.link_to purl_url(@purl), purl_url(@purl)} to view the other versions of this item."
     elsif !@version.head?
-      flash.now[:alert] = 'A newer version of this item is available'
+      flash.now[:alert] = 'A newer version of this item is available.<br>' \
+                          "#{view_context.link_to 'View latest version', purl_url(@purl)}"
     end
   end
 

--- a/spec/requests/purl_spec.rb
+++ b/spec/requests/purl_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe 'PURL API' do
             'Compressed Sensing Phase Transitions of Gaussian Random Matrices.&quot; -- VERSION 1'
           )
           expect(response.body).to include('A newer version of this item is available')
+          expect(response.body).to have_link('View latest version', href: 'http://www.example.com/wp335yr5649')
           expect(response.body).to have_css('div.upper-record-metadata')
           expect(response.body).to have_css('div.record-metadata')
         end


### PR DESCRIPTION
Resolves #1134 to show a "View latest version" link on a non-head version. Andrew has reviewed. 

![Screenshot 2024-08-16 at 12 54 21 PM](https://github.com/user-attachments/assets/81830ace-7c5c-4943-b308-2a13c880084e)
