### PR TITLE
Add URL for right-click actions

### DIFF
--- a/app/components/version_actions_component.html.erb
+++ b/app/components/version_actions_component.html.erb
@@ -4,7 +4,7 @@
   <% else %>
     <%= link_to 'View', version %>
   <% end %>
-  | <a href="#" data-action="click->clipboard#copy">Copy URL</a>
+  | <%= link_to 'Copy URL', version_purl_url(id: version.druid, version: version.version_id), data: { action: "clipboard#copy"} %>
 <% else %>
   <%= state.capitalize %>
 <% end %>


### PR DESCRIPTION
Resolves #1152 so that right-clicking and copying also gets the versioned URL in all browsers. 

@andrewjbtw tested to confirm working as expected. 