### PR TITLE
Fetch collection membership and populate IIIF collection manifests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'whenever', require: false # cron jobs
 gem 'dor-rights-auth', '~> 1.6'
 gem 'iiif-presentation', '~> 1.3'
 gem 'mods_display', '~> 1.5'
+gem 'purl_fetcher-client', '~> 3'
 
 group :production do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,9 @@ GEM
     public_suffix (6.0.1)
     puma (6.6.0)
       nio4r (~> 2.0)
+    purl_fetcher-client (3.0.1)
+      activesupport
+      faraday (~> 2.1)
     racc (1.8.1)
     rack (3.1.12)
     rack-session (2.1.0)
@@ -467,6 +470,7 @@ DEPENDENCIES
   okcomputer
   propshaft
   puma (~> 6.0)
+  purl_fetcher-client (~> 3)
   rails (~> 8.0.0)
   recaptcha
   rspec-rails (~> 7.1)

--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -5,7 +5,7 @@ class Iiif3PresentationManifest < IiifPresentationManifest
   delegate :reading_order, to: :content_metadata
   attr_reader :purl_base_uri
 
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
   def body
     manifest_data = {
       'id' => manifest_url,
@@ -53,6 +53,7 @@ class Iiif3PresentationManifest < IiifPresentationManifest
     manifest.thumbnail = [thumbnail_resource] if thumbnail_resource?
 
     build_canvases(manifest)
+    build_collection_items(manifest) if collection?
 
     manifest
   end
@@ -93,6 +94,17 @@ class Iiif3PresentationManifest < IiifPresentationManifest
       content_metadata.grouped_resources.each do |resource_group|
         manifest.items << canvas_for_resource(resource_group)
       end
+    end
+  end
+
+  def build_collection_items(manifest)
+    # for each member of the collection, add its manifest to the collection's items
+    iiif_collection_members.each do |member|
+      manifest.items << {
+        'id' => manifest_url(id: member['druid'].delete_prefix('druid:')),
+        'label' => { en: [member['title']] },
+        'type' => 'Manifest'
+      }
     end
   end
 
@@ -303,6 +315,8 @@ class Iiif3PresentationManifest < IiifPresentationManifest
     thumb
   end
 
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
+
   def thumbnail_resource?
     thumbnail_image.present?
   end
@@ -412,7 +426,6 @@ class Iiif3PresentationManifest < IiifPresentationManifest
       ]
     )
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def three_d?
     type == '3d'
@@ -440,5 +453,25 @@ class Iiif3PresentationManifest < IiifPresentationManifest
     else
       IIIF::V3::Presentation::Manifest
     end
+  end
+
+  # Subset of collection members that are OK to list in the collection manifest
+  def iiif_collection_members
+    collection_members
+      .select { |member| [iiif_release_targets & member['true_targets']].any? }
+      .select { |member| iiif_content_types.include? member['content_type'] }
+  end
+
+  private
+
+  # Include collection members released to any of these platforms
+  # TODO: create a release tag just for this purpose?
+  def iiif_release_targets
+    %w[Searchworks EarthWorks]
+  end
+
+  # Filter out collection members that can't be rendered in a IIIF viewer
+  def iiif_content_types
+    %w[image book]
   end
 end

--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -6,7 +6,7 @@ class IiifPresentationManifest
   include ActiveModel::Model
 
   delegate :druid, :title, :type, :description, :content_metadata, :public_xml_document, :cocina, :updated_at,
-           :containing_purl_collections, :rights, :collection?, to: :purl_version
+           :containing_purl_collections, :rights, :collection?, :collection_members, to: :purl_version
   delegate :reading_order, :resources, to: :content_metadata
   delegate :url_for, to: :controller
   alias id druid

--- a/app/models/purl_resource.rb
+++ b/app/models/purl_resource.rb
@@ -26,7 +26,8 @@ class PurlResource
              head: head_version == version_id.to_i,
              updated_at: version_attrs.fetch('date', nil),
              state: version_attrs.fetch('state'),
-             resource_retriever: versioned_layout? ? VersionedResourceRetriever.new(druid:, version_id:) : resource_retriever)
+             resource_retriever: versioned_layout? ? VersionedResourceRetriever.new(druid:, version_id:) : resource_retriever,
+             collection_members_retriever: CollectionMembersRetriever.new(druid:))
     end
   end
 

--- a/app/models/purl_version.rb
+++ b/app/models/purl_version.rb
@@ -4,7 +4,7 @@ class PurlVersion # rubocop:disable Metrics/ClassLength
   include ActiveModel::Model
   include ActiveSupport::Benchmarkable
 
-  attr_accessor :id, :head, :state, :resource_retriever
+  attr_accessor :id, :head, :state, :resource_retriever, :collection_members_retriever
   attr_reader :version_id, :updated_at
   alias druid id
 
@@ -239,6 +239,12 @@ class PurlVersion # rubocop:disable Metrics/ClassLength
   end
 
   delegate :public_xml_body, :cocina_body, to: :resource_retriever
+
+  def collection_members
+    # Purl-fetcher only knows current membership at time of querying
+    Rails.logger.warn("Attempting to retrieve collection members for a non-head version #{druid} v#{version_id}") unless head?
+    collection_members_retriever.collection_members if collection?
+  end
 
   def public_xml?
     public_xml_body.present?

--- a/app/services/collection_members_retriever.rb
+++ b/app/services/collection_members_retriever.rb
@@ -1,0 +1,38 @@
+class CollectionMembersRetriever
+  include ActiveSupport::Benchmarkable
+
+  def initialize(druid:)
+    @druid = druid
+  end
+
+  # All objects that list this object as a containing collection in purl-fetcher
+  # TODO: exploit the structure of this response for caching purposes:
+  # purl-fetcher lists most recently changed members first and sends an ETag
+  #
+  # Alternatively, use ActiveRecord hooks in purl-fetcher’s database to
+  # update the collection’s timestamp when its members are modified
+  #
+  # For now, no caching until we know we need it
+  def collection_members
+    @collection_members ||= benchmark "Fetching #{druid} collection_members at #{collection_members_path}" do
+      purl_fetcher_client.collection_members(druid).to_a
+    end
+  end
+
+  private
+
+  attr_reader :druid
+
+  def logger
+    Rails.logger
+  end
+
+  def purl_fetcher_client
+    @purl_fetcher_client ||= PurlFetcher::Client::Reader.new(host: Settings.purl_fetcher.url)
+  end
+
+  # For logging purposes
+  def collection_members_path
+    "#{purl_fetcher_client.host}/collections/#{druid}/purls"
+  end
+end


### PR DESCRIPTION
Ref #84

This uses the new capabilities of purl-fetcher's collections
endpoint to populate and filter a list of collection members,
and then add their manifest URLs to the items list for the
collection's manifest.

Member items are filtered based on their content type and release
status, so that only publicly released items with IIIF-displayable
content types are added. The actual rights of the object are
delegated to the viewer if the manifest is loaded.
