### PR TITLE
Make IIIF v3 presentation provider into an array

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -14,7 +14,7 @@ class Iiif3PresentationManifest < IiifPresentationManifest
         'label' => { en: ['Attribution'] },
         'value' => { en: attribution.compact_blank }
       },
-      'provider' => provider,
+      'provider' => [provider],
       'seeAlso' => [{
         'id' => controller.purl_url(druid, format: 'mods'),
         'type' => 'Metadata',


### PR DESCRIPTION
The spec (https://iiif.io/api/presentation/3.0/#provider) says
that this value must be an array of objects, but we currently
provide just a single object.

This causes the Clover viewer, in particular, to fail to render
manifests and complain that it can't .map() on the provider value.
