### PR TITLE
do not show version information unless there are user versions

### DIFF
--- a/app/components/versions_component.rb
+++ b/app/components/versions_component.rb
@@ -10,11 +10,16 @@ class VersionsComponent < ViewComponent::Base
 
   attr_reader :purl, :label_id
 
+  # we only show version information if the object has user versions
+  def render?
+    purl.version_manifest_body.present?
+  end
+
   def embeddable_url
     @embeddable_url ||= helpers.embeddable_url(purl.druid)
   end
 
   def versions
-    @purl.versions.sort_by(&:version_id).reverse
+    purl.versions.sort_by(&:version_id).reverse
   end
 end

--- a/spec/features/display_purl_page_spec.rb
+++ b/spec/features/display_purl_page_spec.rb
@@ -100,15 +100,17 @@ RSpec.describe 'Displaying the PURL page' do
     end
   end
 
-  context 'revs object' do
+  context 'revs object (no version manifest)' do
     let(:druid) { 'tx027jv4938' }
 
-    it 'displays the page' do
+    it 'displays the page without version information' do
       visit "/#{druid}"
       expect(page).to have_content 'IMSA 24 Hours of Daytona'
       expect(page).to have_metadata_section 'Access conditions'
       expect(page).to have_metadata_section 'Bibliographic information'
       expect(page).to have_content 'Revs ID 2012-015GHEW-BW-1984-b4_1.4_0003'
+      expect(page).to have_no_content 'You are viewing this version'
+      expect(page).to have_no_content 'Each version has a distinct URL, but you can use this PURL to access the latest version.'
     end
   end
 
@@ -235,9 +237,17 @@ RSpec.describe 'Displaying the PURL page' do
     end
   end
 
-  context 'with a version' do
+  context 'with a version manifest' do
+    let(:druid) { 'wp335yr5649' }
+
+    it 'shows the version information panel' do
+      visit "/#{druid}"
+      expect(page).to have_content 'You are viewing this version'
+      expect(page).to have_content 'Each version has a distinct URL, but you can use this PURL to access the latest version.'
+    end
+
     it 'draws the page' do
-      visit '/wp335yr5649/version/3'
+      visit "/#{druid}/version/3"
       link = page.find('link[rel="alternate"][title="oEmbed Profile"][type="application/json+oembed"]', visible: false)
       expect(link['href']).to eq 'https://embed.stanford.edu/embed.json?url=https%3A%2F%2Fpurl.stanford.edu%2Fwp335yr5649%2Fversion%2F3'
     end


### PR DESCRIPTION
See #1242 and https://stanfordlib.slack.com/archives/C09M7P91R/p1743613931774519

Basically, the `updated at` date we show for PURLs that have never had any user versions can be inaccurate, since it shows the last time the PURL was published, which can be more recent than the time the object was actually accessioned.

It may be possible to get this date in these cases from SDR through purl-fetcher and on to Purl, but it could be complicated (I'm not sure, but you can see some of my investigations in the ticket comments).  

Andrew suggested simply not showing the date in these cases since it was never shown before, and I think it probably doesn't even make sense to show the version panel either, since there isn't anything useful there.  My read of the code is that without user versions for the object, it will only ever show one version in that panel anyway, and the date could be wrong.  

See https://github.com/sul-dlss/purl/blob/main/app/models/purl_resource.rb#L21-L31 and https://github.com/sul-dlss/purl/blob/main/app/models/purl_resource.rb#L73-L93 (i.e. no version manifest?  no useful version info to display)

Verified on stage (by deploying this branch):
- example with user versions that still shows the version panel: https://sul-purl-stage.stanford.edu/bc670fy5418
- example without user versions that hides the version panel: https://sul-purl-stage.stanford.edu/bb011nz8100

ToDo:
- [x] test on stage
- [x] add tests

**example of before:**
<img width="463" alt="Screenshot 2025-04-03 at 12 24 35 PM" src="https://github.com/user-attachments/assets/245d0cf4-a274-4b83-a92f-ebd7dc482de8" />


**after:**
<img width="484" alt="Screenshot 2025-04-03 at 12 25 00 PM" src="https://github.com/user-attachments/assets/844b91d6-0896-44e1-91d3-eb8c71fba009" />



