### PR TITLE
Use reCAPTCHA v3 on the feedback form

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -125,3 +125,7 @@
 .section-header {
   color: var(--stanford-cardinal);
 }
+
+.grecaptcha-badge {
+  visibility: hidden;
+}

--- a/app/components/recaptcha_component.html.erb
+++ b/app/components/recaptcha_component.html.erb
@@ -1,0 +1,4 @@
+<div class="recaptcha" data-recaptcha-target="tags" data-recaptcha-action-value="<%= action %>" data-recaptcha-site-key-value="<%= site_key %>">
+  This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+  <%= recaptcha_v3 action:, inline_script:, site_key: %>
+</div>

--- a/app/components/recaptcha_component.rb
+++ b/app/components/recaptcha_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RecaptchaComponent < ViewComponent::Base
+  attr_reader :action, :inline_script, :site_key
+
+  def initialize(action:, inline_script: false, site_key: Recaptcha.configuration.site_key)
+    @action = action
+    @inline_script = inline_script
+    @site_key = site_key
+    super
+  end
+end

--- a/app/controllers/feedback_forms_controller.rb
+++ b/app/controllers/feedback_forms_controller.rb
@@ -17,6 +17,6 @@ class FeedbackFormsController < ApplicationController
   protected
 
   def pass_captcha?
-    current_user.present? || verify_recaptcha
+    current_user.present? || verify_recaptcha(action: 'feedback')
   end
 end

--- a/app/javascript/controllers/recaptcha_controller.js
+++ b/app/javascript/controllers/recaptcha_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="recaptcha"
+export default class extends Controller {
+  // Target for the `RecaptchaComponent`, which contains the data attributes for action & siteKey
+  static targets = [ "tags" ]
+
+  async refresh(event) {
+    // The recaptcha tags aren't always rendered (e.g., if a user is logged in).
+    if (!this.isRecaptchaEnabled()) return
+
+    event.preventDefault()
+    await this.execute()
+
+    if (this.isUsingTurbo(event)) {
+      Turbo.navigator.submitForm(event.target)
+    } else {
+      event.target.submit()
+    }
+  }
+
+  isRecaptchaEnabled() {
+    return this.hasTagsTarget ? true : false
+  }
+
+  isUsingTurbo(event) {
+    if (event.target.getAttribute('data-turbo') === 'false') {
+      return false;
+    }
+
+    return typeof Turbo !== 'undefined';
+  }
+
+  recaptchaElement() {
+    const action = this.action().replace('_', '-')
+    const recaptchaId = `g-recaptcha-response-data-${action}`
+    return document.getElementById(recaptchaId);
+  }
+
+  action() {
+    return this.tagsTarget.getAttribute('data-recaptcha-action-value')
+  }
+
+  siteKey() {
+    return this.tagsTarget.getAttribute('data-recaptcha-site-key-value')
+  }
+
+  async execute() {
+    const recaptchaElement = this.recaptchaElement()
+    if (!recaptchaElement || typeof grecaptcha === 'undefined') return
+
+    const response = await grecaptcha.execute(this.siteKey(), { action: this.action() })
+    if (response) recaptchaElement.value = response
+  }
+}

--- a/app/views/feedback_forms/new.html.erb
+++ b/app/views/feedback_forms/new.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="feedback-form-frame">
   <div class="row justify-content-md-center">
     <div class="col-sm-6 my-3">
-      <%= form_tag feedback_form_path, method: :post, class:"form-horizontal feedback-form", role:"form", data: { turbo: false, controller: 'feedback', feedback_target: 'form' } do %>
+      <%= form_tag feedback_form_path, method: :post, class:"form-horizontal feedback-form", role:"form", data: { turbo: false, controller: 'feedback recaptcha', feedback_target: 'form', action: 'submit->recaptcha#refresh' } do %>
         <div class="row">
           <div class="col-sm-12 px-4 mb-2">
             <div class="alert alert-info" role="alert">
@@ -34,10 +34,7 @@
           <% if current_user.blank? %>
             <div class="form-group row mb-3">
               <div class="offset-sm-3 col-sm-9">
-                <%# no_script causes multiple response parameters to be submitted, which breaks verification. %>
-                <%= recaptcha_tags noscript: false %>
-
-                <p>(Stanford users can avoid this Captcha by logging in.)</p>
+                <%= render RecaptchaComponent.new(action: 'feedback') %>
               </div>
             </div>
           <% end %>

--- a/spec/components/recaptcha_component_spec.rb
+++ b/spec/components/recaptcha_component_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RecaptchaComponent, type: :component do
+  before do
+    render_inline(described_class.new(action: 'feedback'))
+  end
+
+  it 'renders the component' do
+    expect(page).to have_css '[data-recaptcha-target="tags"]'
+    expect(page).to have_css '[data-recaptcha-action-value="feedback"]'
+    expect(page).to have_css '[data-recaptcha-site-key-value]'
+    expect(page).to have_text 'This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply'
+    expect(page).to have_link href: 'https://policies.google.com/privacy'
+    expect(page).to have_link href: 'https://policies.google.com/terms'
+  end
+end


### PR DESCRIPTION
Closes #1263 

Moves to reCAPTCHA v3 that has no visible challenge or need to encourage login. This is the same setup SearchWorks uses.

<img width="639" height="371" alt="Screenshot 2025-07-28 at 2 02 15 PM" src="https://github.com/user-attachments/assets/7a17892e-1821-4a45-b847-1871bcaf6265" />

I believe we'll need to merge this first, then [the puppet PR with the ENV vars](https://github.com/sul-dlss/puppet/pull/12685), then cut a new purl release in short order after the new ENV variables take effect. If that all works then I'll remove the old reCAPTCHA v2 keys from shared config.