### PR TITLE
fix v3 manifest validator errors

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -30,8 +30,8 @@ class Iiif3PresentationManifest < IiifPresentationManifest
 
     manifest = iiif_manifest_class.new(manifest_data)
 
-    # Set viewingHint to paged if this is a book
-    manifest.viewingHint = 'paged' if type == 'book'
+    # Set behavior to paged if this is a book
+    manifest['behavior'] = ['paged'] if type == 'book'
     (_collection, collection_head_version) = containing_purl_collections&.first
     collection_title = collection_head_version&.title
     metadata_writer = Iiif3MetadataWriter.new(cocina_descriptive: cocina['description'],
@@ -139,7 +139,7 @@ class Iiif3PresentationManifest < IiifPresentationManifest
       canv[canvas_type] = thumbnail_canvas
 
       canv['annotations'] = supplementing_resources_annotation_page(resource_group)
-      canv['renderings'] = renderings_for_resource_group(resource_group)
+      canv['rendering'] = renderings_for_resource_group(resource_group)
     end
 
     canv
@@ -216,13 +216,13 @@ class Iiif3PresentationManifest < IiifPresentationManifest
     img_res.width = resource.width
 
     img_res.service = [iiif_image_v2_service(url)]
-    img_res.service[0]['service'] = []
+    img_res.service[0]['services'] = []
     if rights.stanford_only_rights_for_file(resource.filename).first
-      img_res.service[0]['service'].append(iiif_stacks_v1_login_service)
+      img_res.service[0]['services'].append(iiif_stacks_v1_login_service)
     end
 
     if rights.restricted_by_location?(resource.filename)
-      img_res.service[0]['service'].append(iiif_location_auth_service)
+      img_res.service[0]['services'].append(iiif_location_auth_service)
     end
 
     img_res
@@ -245,7 +245,7 @@ class Iiif3PresentationManifest < IiifPresentationManifest
     file_url = stacks_version_file_url(resource.druid, resource.filename)
     bin_res['id'] = file_url
     bin_res['type'] = iiif_resource_type(resource)
-    bin_res['label'] = resource.filename
+    bin_res['label'] = { en: [resource.filename] }
     bin_res.format = resource.mimetype
 
     bin_res.service = [probe_service(resource, file_url)]

--- a/spec/requests/iiif3_manifest_spec.rb
+++ b/spec/requests/iiif3_manifest_spec.rb
@@ -132,9 +132,9 @@ RSpec.describe 'IIIF v3 manifests' do
       expect(canvas['items'].first['items'].length).to eq 1
       image = canvas['items'].first['items'].first
       service = image['body']['service'].first
-      expect(service['service']).to include hash_including 'profile' => 'http://iiif.io/api/auth/1/login'
+      expect(service['services']).to include hash_including 'profile' => 'http://iiif.io/api/auth/1/login'
 
-      login_service = service['service'].detect { |x| x['profile'] == 'http://iiif.io/api/auth/1/login' }
+      login_service = service['services'].detect { |x| x['profile'] == 'http://iiif.io/api/auth/1/login' }
       expect(login_service['service']).to include hash_including 'profile' => 'http://iiif.io/api/auth/1/token'
       expect(login_service['label']).to eq 'Log in to access all available features.'
       expect(login_service['confirmLabel']).to eq 'Login'
@@ -423,7 +423,7 @@ RSpec.describe 'IIIF v3 manifests' do
       get "/#{druid}/iiif3/manifest"
       expect(response).to have_http_status(:ok)
 
-      external_interaction_service = json['items'].first['items'].first['items'].first['body']['service'].first['service'].first
+      external_interaction_service = json['items'].first['items'].first['items'].first['body']['service'].first['services'].first
       expect(external_interaction_service['profile']).to eq 'http://iiif.io/api/auth/1/external'
       expect(external_interaction_service['label']).to eq 'External Authentication Required'
       expect(external_interaction_service['failureHeader']).to eq 'Restricted Material'


### PR DESCRIPTION
This fixes all but one error. The last error is because we are adding a pdf to the image canvas. Basically we have image01, image02, fullpdf as its own canvas. We shouldn't do this but becasue of the mixed nature of our content I would like this to be a separate issue.

Issues addressed in this PR

Before:
<img width="1141" height="804" alt="Screenshot 2025-08-08 at 1 23 41 PM" src="https://github.com/user-attachments/assets/53ada62a-b297-4ba6-98c7-8dba5dd5d22e" />



After:
<img width="1108" height="711" alt="Screenshot 2025-08-08 at 1 21 48 PM" src="https://github.com/user-attachments/assets/e467e180-db2b-4765-8c90-2e1d6465f93a" />
