### PR TITLE
update display label before type

### DIFF
--- a/app/models/iiif3_metadata_writer.rb
+++ b/app/models/iiif3_metadata_writer.rb
@@ -105,7 +105,7 @@ class Iiif3MetadataWriter
   def extract_notes
     values = {}
     Array(cocina_descriptive['note']).each do
-      key = (it['type'] || 'Description').capitalize
+      key = it['displayLabel'] || it['type']&.capitalize || 'Description'
       values[key] ||= []
       values[key] += structured_values(it)
     end

--- a/spec/model/iiif3_metadata_writer_spec.rb
+++ b/spec/model/iiif3_metadata_writer_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe Iiif3MetadataWriter do
 
       it 'extracts the metadata' do
         expect(metadata.find do
-          it['label'][:en] == ['Table of contents']
+          it['label'][:en] == ['Contents']
         end['value'][:en]).to include('Of the leaven of pharisees')
       end
     end

--- a/spec/requests/iiif3_manifest_spec.rb
+++ b/spec/requests/iiif3_manifest_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'IIIF v3 manifests' do
       expect(image['body']['id']).to eq 'https://stacks.stanford.edu/image/iiif/bb157hs6068%2Fbb157hs6068_05_0001/full/full/0/default.jpg'
 
       expect(json['metadata'].class).to eq Array
-      expect(json['metadata'].size).to eq(15)
+      expect(json['metadata'].size).to eq 15
       expect(json['metadata']).to eq(expected_dc_metadata)
     end
   end
@@ -407,7 +407,11 @@ RSpec.describe 'IIIF v3 manifests' do
       get "/#{druid}/iiif3/manifest"
       expect(response).to have_http_status(:ok)
       expect(json['label']['en'].first).to eq '10 Meter Contours: Russian River Basin, California'
-      expect(json['metadata'].size).to eq 12
+      expect(json['metadata'].size).to eq 15
+      expect(json['metadata'].flat_map do |elem|
+        elem['label']['en']
+      end).to eq ['Available Online', 'Title', 'Type', 'Format', 'Language', 'Abstract', 'Purpose', 'Preferred citation',
+                  'Supplemental information', 'WGS84 Cartographics', 'Subject', 'Coverage', 'Date', 'Identifier', 'PublishDate']
     end
   end
 


### PR DESCRIPTION
In the image below you can see we are using the type 'local', there is a displayLabel which clearly says it is a localNote. Using the displayLabel should be the preference considering it is set by the user.

The difference of fields in cg357zz0321 is Description is removed. The fields that used to be in there are mapped to "Purpose", "Preferred citation", "Supplemental information", "WGS84 Cartographics".
![](https://private-user-images.githubusercontent.com/19173991/477742272-f8fba5f9-4fa8-4cd2-b888-d5f749c373c1.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTUyMDkzNTAsIm5iZiI6MTc1NTIwOTA1MCwicGF0aCI6Ii8xOTE3Mzk5MS80Nzc3NDIyNzItZjhmYmE1ZjktNGZhOC00Y2QyLWI4ODgtZDVmNzQ5YzM3M2MxLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA4MTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwODE0VDIyMDQxMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFiM2I3ZjcxMTI0YjA4YzVlOGE2ODQzOGQxYjljNDdhNWM0NWI3ZTAwMTU1ZmRkY2NhOTQxZTg4ZGZmZWY1MzcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.wL5k9zUBO157oDKSufEqhfcCTz_ozvr1v4YwJs1nCFE)