### PR TITLE
Construct test data about withdrawn version

### DIFF
--- a/spec/requests/purl_spec.rb
+++ b/spec/requests/purl_spec.rb
@@ -61,8 +61,27 @@ RSpec.describe 'PURL API' do
       end
 
       context 'when a withdrawn version is provided' do
+        let(:version) do
+          PurlVersion.new(id: 'bw368gx2874',
+                          version_id: 3,
+                          head: false,
+                          updated_at: 1.day.ago,
+                          state: 'withdrawn',
+                          resource_retriever:)
+        end
+        let(:resource_retriever) do
+          instance_double(ResourceRetriever, public_xml_body: '<xml></xml>', cocina_body:)
+        end
+        let(:cocina_body) do
+          '{"cocinaVersion": "0.100.text", "version": 5,"type": "https://cocina.sul.stanford.edu/models/image", "structural": {}}'
+        end
+
+        before do
+          allow(PurlResource).to receive(:find).and_return(instance_double(PurlResource, version:))
+        end
+
         it 'returns the Cocina json for the requested version' do
-          get '/wp335yr5649/version/3.json'
+          get '/bw368gx2874/version/3.json'
           expect(response).to be_successful
           expect(response.parsed_body).to include('type', 'structural', 'status')
           expect(response.parsed_body['status']).to eq('withdrawn')
@@ -94,8 +113,27 @@ RSpec.describe 'PURL API' do
       end
 
       context 'when a withdrawn version is provided' do
+        let(:version) do
+          PurlVersion.new(id: 'bw368gx2874',
+                          version_id: 3,
+                          head: false,
+                          updated_at: 1.day.ago,
+                          state: 'withdrawn',
+                          resource_retriever:)
+        end
+        let(:resource_retriever) do
+          instance_double(ResourceRetriever, public_xml_body: '<xml></xml>', cocina_body:)
+        end
+        let(:cocina_body) do
+          '{"cocinaVersion": "0.100.text", "version": 5,"type": "https://cocina.sul.stanford.edu/models/image", "structural": {}}'
+        end
+
+        before do
+          allow(PurlResource).to receive(:find).and_return(instance_double(PurlResource, version:))
+        end
+
         it 'returns the public XML for the requested version' do
-          get '/wp335yr5649/version/3.xml'
+          get '/bw368gx2874/version/3.xml'
           expect(response).to be_successful
         end
       end
@@ -138,8 +176,42 @@ RSpec.describe 'PURL API' do
       end
 
       context 'with withdrawn version specified' do
+        let(:version) do
+          PurlVersion.new(id: 'bw368gx2874',
+                          version_id: 3,
+                          head: false,
+                          updated_at: 1.day.ago,
+                          state: 'withdrawn',
+                          resource_retriever:)
+        end
+        let(:resource_retriever) do
+          instance_double(ResourceRetriever, public_xml_body:, cocina_body:)
+        end
+
+        let(:public_xml_body) do
+          <<~XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <publicObject id="druid:bw368gx2874" published="2023-10-26T11:21:31Z" publishVersion="cocina-models/0.91.4">
+              <mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.7" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd">
+                <titleInfo>
+                  <title>Code and Data supplement to "Deterministic Matrices Matching the Compressed Sensing Phase Transitions of Gaussian Random Matrices." -- VERSION 3</title>
+                </titleInfo>
+              </mods>
+            </publicObject>
+          XML
+        end
+        let(:cocina_body) do
+          '{"cocinaVersion": "0.100.text", "version": 5,"type": "https://cocina.sul.stanford.edu/models/image", "structural": {}}'
+        end
+        let(:purl_resource) { PurlResource.new(id: 'bw368gx2874') }
+
+        before do
+          allow(PurlResource).to receive(:find).and_return(purl_resource)
+          allow(purl_resource).to receive_messages(version:, crawlable?: false)
+        end
+
         it 'returns the PURL page of the requested version with only tombstone information' do
-          get '/wp335yr5649/version/3'
+          get '/bw368gx2874/version/3'
           expect(response).to have_http_status(:ok)
           expect(response.body).to include(
             'Code and Data supplement to &quot;Deterministic Matrices Matching the ' \
@@ -147,7 +219,7 @@ RSpec.describe 'PURL API' do
           )
           expect(response.body).not_to include('A newer version of this item is available')
           expect(response.body).to include('This version has been withdrawn')
-          expect(response.body).to include('Please visit <a href="http://www.example.com/wp335yr5649">http://www.example.com/wp335yr5649</a> ' \
+          expect(response.body).to include('Please visit <a href="http://www.example.com/bw368gx2874">http://www.example.com/bw368gx2874</a> ' \
                                            'to view the other versions of this item.')
           expect(response.body).not_to include('Description')
           expect(response.body).not_to include('Preferred citation')


### PR DESCRIPTION
It isn't actually present in that fixture, so refreshing it wipes it out