### PR TITLE
Avoid using a whole fixture, when we can just use the relevant metada…

### DIFF
--- a/spec/model/iiif3_metadata_writer_spec.rb
+++ b/spec/model/iiif3_metadata_writer_spec.rb
@@ -381,7 +381,14 @@ RSpec.describe Iiif3MetadataWriter do
 
     context 'with language' do
       let(:cocina_descriptive) do
-        PurlResource.find('zf119tw4418').version(:head).cocina['description']
+        {
+          'language' =>
+          [{
+            'code' => 'eng',
+            'source' => { 'code' => 'iso639-2b' },
+            'structuredValue' => []
+          }]
+        }
       end
 
       it 'extracts the metadata' do
@@ -393,7 +400,33 @@ RSpec.describe Iiif3MetadataWriter do
 
     context 'with nested subject' do
       let(:cocina_descriptive) do
-        PurlResource.find('zf119tw4418').version(:head).cocina['description']
+        {
+          'subject' =>
+          [{
+            'type' => 'place',
+            'code' => 'n-us',
+            'source' => { 'code' => 'marcgac' }
+          },
+           { 'structuredValue' =>
+             [{ 'structuredValue' =>
+                [{ 'value' => 'United States' },
+                 { 'value' => 'Department of Energy' },
+                 { 'value' => 'Office of Inspector General' }],
+                'type' => 'organization' },
+              {
+                'value' => 'Auditing',
+                'type' => 'topic'
+              },
+              {
+                'value' => 'Statistics',
+                'type' => 'genre'
+              },
+              {
+                'value' => 'Periodicals',
+                'type' => 'genre'
+              }],
+             'source' => { 'code' => 'lcsh', 'note' => [] } }]
+        }
       end
 
       it 'extracts the metadata' do


### PR DESCRIPTION
…ta for testing

This was not a great fixture to use as it's an out of date style of book because it has image constituents and doesn't shelve the OCR.