### PR TITLE
Avoid a negation matcher after visit in feature specs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-Capybara/NegationMatcherAfterVisit:
-  Exclude:
-    - 'spec/features/display_purl_page_spec.rb'
-
 # Offense count: 1
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches, IgnoreDuplicateElseBranch.
 Lint/DuplicateBranch:

--- a/spec/features/display_purl_page_spec.rb
+++ b/spec/features/display_purl_page_spec.rb
@@ -141,10 +141,11 @@ RSpec.describe 'Displaying the PURL page' do
   end
 
   context 'with an item that is crawlable' do
-    let(:druid) { 'gb089bd2251' }
+    let(:druid) { 'nd387jf5675' }
 
     it 'excludes noindex meta tag' do
       visit "/#{druid}"
+      expect(page).to have_content 'Invariance for perceptual recognition through deep learning'
       expect(page).to have_no_css 'meta[name="robots"][content="noindex"]', visible: :hidden
     end
   end
@@ -190,16 +191,10 @@ RSpec.describe 'Displaying the PURL page' do
   context 'with an incomplete/unpublished object (not in stacks)' do
     let(:druid) { 'fb123cd4567' }
 
-    it 'gives 404 with unavailable message' do
+    it 'gives unavailable message and a feedback form', :js do
       visit "/#{druid}"
-      expect(page.status_code).to eq(404)
       expect(page).to have_content 'The item you requested is not available.'
       expect(page).to have_content 'This item is in processing or does not exist. If you believe you have reached this page in error, please send Feedback.'
-    end
-
-    it 'includes a feedback link that toggled the feedback form', :js do
-      allow(Settings.feedback).to receive(:email_to).and_return('feedback@example.com')
-      visit "/#{druid}"
 
       expect(page).to have_no_css('form.feedback-form', visible: :visible)
 


### PR DESCRIPTION
This can be a false negative unless we first check that the page is loaded