### PR TITLE
Stop reporting errors for missing collections

### DIFF
--- a/app/models/purl_version.rb
+++ b/app/models/purl_version.rb
@@ -61,8 +61,8 @@ class PurlVersion # rubocop:disable Metrics/ClassLength
       return nil unless resource.version(:head).ready?
 
       [resource, resource.version(:head)]
-    rescue ResourceRetriever::ResourceNotFound => e
-      Honeybadger.notify(e)
+    rescue ResourceRetriever::ResourceNotFound
+      # The collection is not available, likely because it is "dark"
       nil
     end
   end


### PR DESCRIPTION
It's often the case there are dark collections with visible items in them. https://argo.stanford.edu/catalog\?f%5BobjectType_ssim%5D%5B%5D\=collection\&f%5Brights_descriptions_ssim%5D%5B%5D\=dark

Fixes #1436