### PR TITLE
Remove root_path from settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Then run tests to see if anything needs to be updated.  Commit the changes to th
 Deployment is handled automatically via Jenkins when a release is published to GitHub.
 
 ## Data
-Purl data is stored in a pair-tree structure starting at `Settings.document_cache_root`.  In each pair-tree is a file called `cocina.json` which is the public representation of the current version of the object.  There is also a `meta.json` file that holds information about where this object is released to.  The `meta.json` is not versionable data.  Additionally there is an XML file called `public` which has a representation of the object that was derived from `cocina.json`.
+Purl data is stored in a pair-tree structure starting at `/stacks`.  In each pair-tree is a file called `cocina.json` which is the public representation of the current version of the object.  There is also a `meta.json` file that holds information about where this object is released to.  The `meta.json` is not versionable data.  Additionally there is an XML file called `public` which has a representation of the object that was derived from `cocina.json`.
 
 ## Search engine indexing
 

--- a/app/services/resource_retriever.rb
+++ b/app/services/resource_retriever.rb
@@ -50,13 +50,8 @@ class ResourceRetriever
   def attributes
     {
       druid:,
-      druid_tree:,
-      root_path:
+      druid_tree:
     }
-  end
-
-  def root_path
-    Settings.document_cache_root
   end
 
   def druid_tree

--- a/app/services/versioned_resource_retriever.rb
+++ b/app/services/versioned_resource_retriever.rb
@@ -13,12 +13,7 @@ class VersionedResourceRetriever < ResourceRetriever
   attr_reader :version_id
 
   def attributes
-    {
-      druid:,
-      druid_tree:,
-      root_path:,
-      version_id:
-    }
+    super.merge(version_id:)
   end
 
   def cache_key(key)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -12,8 +12,7 @@ OkComputer::Registry.deregister "database" # don't check (unused) ActiveRecord d
 #  individual checks also avail at /status/<name-of-check>
 OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new
 
-OkComputer::Registry.register 'document_cache_root',
-  OkComputer::DirectoryCheck.new(Settings.document_cache_root)
+OkComputer::Registry.register 'stacks_fs', OkComputer::DirectoryCheck.new('/stacks')
 
 # NOTE:
 # Settings.purl_resource.public_xml, Settings.purl_resource.mods, and Settings.purl_resource.iiif_manifest

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,8 +9,6 @@ purl_fetcher:
 content_search:
   url:
 
-document_cache_root: "<%= File.join(Rails.root, 'document_cache') %>"
-
 resource_cache:
   enabled: true
   lifetime: <%= 1.hour %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,15 +1,14 @@
-document_cache_root: "<%= File.join(Rails.root, "spec", "fixtures", "document_cache") %>"
 purl_resource:
-  public_xml: "%{root_path}/%{druid_tree}/public"
-  cocina: "%{root_path}/%{druid_tree}/cocina.json"
-  meta: "%{root_path}/%{druid_tree}/meta.json"
+  public_xml: "spec/fixtures/document_cache/%{druid_tree}/public"
+  cocina: "spec/fixtures/document_cache/%{druid_tree}/cocina.json"
+  meta: "spec/fixtures/document_cache/%{druid_tree}/meta.json"
   versioned:
-    public_xml: "%{root_path}/%{druid_tree}/%{druid}/versions/public.%{version_id}.xml"
-    cocina: "%{root_path}/%{druid_tree}/%{druid}/versions/cocina.%{version_id}.json"
-    meta: "%{root_path}/%{druid_tree}/%{druid}/versions/meta.json"
+    public_xml: "spec/fixtures/document_cache/%{druid_tree}/%{druid}/versions/public.%{version_id}.xml"
+    cocina: "spec/fixtures/document_cache/%{druid_tree}/%{druid}/versions/cocina.%{version_id}.json"
+    meta: "spec/fixtures/document_cache/%{druid_tree}/%{druid}/versions/meta.json"
 
 stacks:
-  version_manifest_path: "%{root_path}/%{druid_tree}/%{druid}/versions/versions.json"
+  version_manifest_path: "spec/fixtures/document_cache/%{druid_tree}/%{druid}/versions/versions.json"
 
 content_search:
   url: "http://example.com/content_search/%{druid}/search"


### PR DESCRIPTION
`document_cache` is a term from the PURL filesystem, but we are no longer reading out of /purl, so we should also remove the `document_cache_root`. 