### PR TITLE
Move authors to AltmetricsComponent to resolve TODO

### DIFF
--- a/app/components/altmetrics_component.rb
+++ b/app/components/altmetrics_component.rb
@@ -8,7 +8,7 @@ class AltmetricsComponent < ViewComponent::Base
 
   attr_reader :purl_version
 
-  delegate :display_title, :authors, :doi_id, to: :purl_version
+  delegate :display_title, :doi_id, to: :purl_version
   delegate :cocina_display, :druid, to: :purl_version
 
   def publication_date
@@ -22,5 +22,9 @@ class AltmetricsComponent < ViewComponent::Base
 
     Honeybadger.notify("Malformed Cocina data: No date node found in creation event at description.adminMetadata.event.*.date for: #{druid}")
     nil
+  end
+
+  def authors
+    cocina_display.contributors.map(&:display_name)
   end
 end

--- a/app/models/purl_version.rb
+++ b/app/models/purl_version.rb
@@ -239,11 +239,6 @@ class PurlVersion # rubocop:disable Metrics/ClassLength
     def doi_id
       doi&.delete_prefix('https://doi.org/')
     end
-
-    # TODO: Move to AltmetricsComponent
-    def authors
-      cocina_display.contributors.map(&:display_name)
-    end
   end
 
   concerning :Caching do


### PR DESCRIPTION
This method is only used in the AltmetricsComponent, so keep it there.