### PR TITLE
fix annotation page url for non-image types

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -146,7 +146,7 @@ class Iiif3PresentationManifest < IiifPresentationManifest
 
   def annotation_page(fileset_id:)
     selected_resource = file_sets.find { |fileset| fileset.cocina_id == fileset_id }
-    annotation_page_for_file(selected_resource.image_file) if selected_resource
+    annotation_page_for_file(selected_resource.primary) if selected_resource
   end
 
   def canvas_for_fileset(fileset, file: fileset.primary)

--- a/spec/requests/iiif3_manifest_spec.rb
+++ b/spec/requests/iiif3_manifest_spec.rb
@@ -80,5 +80,12 @@ RSpec.describe 'IIIF v3 manifests' do
         expect(json['label']['en']).to eq ['Minutes, 2006 May 18']
       end
     end
+
+    context 'when a requesting an annotation page' do
+      it 'renders' do
+        get '/fs053dj6001/iiif3/annotation_page/cocina-fileSet-fs053dj6001-fs053dj6001_1'
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #1573 

I am not quite sure we should be resolving annotation page urls but this is a patch until we can figure out if we can get rid of this.