### PR TITLE
Load purls in the controller

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -7,9 +7,15 @@ class PurlController < ApplicationController
 
   rescue_from ActionController::UnknownFormat, with: :missing_file
 
+  FrontPageItem = Data.define(:purl, :title)
   # Landing page for purl.
   # Shows a list of selected druids.
-  def index; end
+  def index
+    @front_page_items = Settings.landing_page_druids.map do |druid|
+      purl = Purl.find(druid)
+      FrontPageItem.new(purl: purl, title: purl.version(:head).display_title)
+    end
+  end
 
   # entry point into the application
   # rubocop:disable Metrics/AbcSize

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,10 +6,4 @@ module ApplicationHelper
   def show_feedback_form?
     Settings.feedback.email_to.present? && !current_page?(feedback_path)
   end
-
-  def link_to_purl(druid)
-    link_to Purl.find(druid).version(:head).display_title, purl_url(druid), class: 'su-underline'
-  rescue StandardError
-    link_to druid, purl_url(druid), class: 'su-underline'
-  end
 end

--- a/app/views/purl/index.html.erb
+++ b/app/views/purl/index.html.erb
@@ -23,15 +23,13 @@
   </div>
 </div>
 
-<% if Settings.landing_page_druids.present? %>
 <div class="row">
   <div class="col-md-12">
     <h3>Featured Items</h3>
     <ul>
-      <% Settings.landing_page_druids.each do |druid| %>
-        <li><%= link_to_purl(druid) %></li>
+      <% @front_page_items.each do |item| %>
+        <li><%= link_to item.title, item.purl, class: 'su-underline' %></li>
       <% end %>
     </ul>
   </div>
 </div>
-<% end %>

--- a/spec/requests/purl_spec.rb
+++ b/spec/requests/purl_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'PURL API' do
   describe 'root page' do
+    before do
+      allow(Settings).to receive(:landing_page_druids).and_return(['bc854fy5899'])
+    end
+
     context 'when html is requested' do
       it 'links to selected druids' do
         get '/'


### PR DESCRIPTION
This avoids loads from the data store from occurring within the view template/helpers.