### PR TITLE
Remove unused link

### DIFF
--- a/app/components/show/head_metadata_component.rb
+++ b/app/components/show/head_metadata_component.rb
@@ -13,7 +13,7 @@ module Show
     delegate :embeddable?, :containing_collections, :version_id, :cocina_body, :druid, :display_title, :description,
              :representative_thumbnail, :representative_thumbnail?, :withdrawn?, to: :version
     delegate :releases, to: :purl
-    delegate :embeddable_url, :oembed_url_template, to: :helpers
+    delegate :embeddable_url, to: :helpers
 
     def schema_dot_org?
       ::Metadata::SchemaDotOrg.schema_type?(cocina_body)
@@ -29,6 +29,10 @@ module Show
 
     def oembed_path(format)
       oembed_url_template.expand(format: format, application_options: oembed_url_template_options, url: embeddable_url(druid, version_id))
+    end
+
+    def oembed_url_template
+      @oembed_url_template ||= Addressable::Template.new(Settings.embed.url_template)
     end
 
     def oembed_url_template_options

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,14 +13,6 @@ module ApplicationHelper
     link_to druid, purl_url(druid), class: 'su-underline'
   end
 
-  def oembed_url_template
-    @oembed_url_template ||= Addressable::Template.new(Settings.embed.url_template)
-  end
-
-  def oembed_provider_url(options = {})
-    oembed_url_template.expand(format: 'json', application_options: Settings.embed.application_options.to_h.merge(options))
-  end
-
   def embeddable_url(druid, version_id = nil)
     format(Settings.embed.url, druid:).tap do |embed_url|
       return "#{embed_url}/version/#{version_id}" if version_id.present? && request.path == version_purl_path(druid, version_id)

--- a/app/views/purl/_embed.html.erb
+++ b/app/views/purl/_embed.html.erb
@@ -3,7 +3,6 @@
     <title>Placeholder</title>
     <rect width="100%" height="100%" fill="#868e96"></rect>
   </svg>
-  <a class="purl-embed-viewer embed su-underline" href="<%= embeddable_url(@purl.druid, @version&.version_id) %>" data-oembed-provider="<%= oembed_provider_url %>">Show Content</a>
 <% end %>
 <noscript>
   <p>Please enable JavaScript to view the embedded content.</p>

--- a/spec/views/purl/_embed.html.erb_spec.rb
+++ b/spec/views/purl/_embed.html.erb_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe 'purl/_embed' do
 
   it 'displays a purl embed viewer' do
     render
-    expect(rendered).to have_css '.purl-embed-viewer'
-    embed = Nokogiri::HTML(rendered).css('.purl-embed-viewer')
-    expect(embed.attr('data-oembed-provider').to_s).to eq 'https://embed.stanford.edu/embed.json?hide_title=true&new_viewer=false'
-    expect(embed.attr('href').to_s).to eq('https://purl.stanford.edu/bf973rp9392')
+    expect(rendered).to have_css '[data-controller="oembed"]'
   end
 
   it 'displays a non-javascript fallback' do
@@ -31,10 +28,7 @@ RSpec.describe 'purl/_embed' do
 
     it 'displays a purl embed viewer with the version' do
       render
-      expect(rendered).to have_css '.purl-embed-viewer'
-      embed = Nokogiri::HTML(rendered).css('.purl-embed-viewer')
-      expect(embed.attr('data-oembed-provider').to_s).to eq 'https://embed.stanford.edu/embed.json?hide_title=true&new_viewer=false'
-      expect(embed.attr('href').to_s).to eq('https://purl.stanford.edu/bf973rp9392/version/2')
+      expect(rendered).to have_css '[data-controller="oembed"]'
     end
 
     it 'displays a non-javascript fallback' do
@@ -53,10 +47,7 @@ RSpec.describe 'purl/_embed' do
 
     it 'does not display a purl embed viewer with a version' do
       render
-      expect(rendered).to have_css '.purl-embed-viewer'
-      embed = Nokogiri::HTML(rendered).css('.purl-embed-viewer')
-      expect(embed.attr('data-oembed-provider').to_s).to eq 'https://embed.stanford.edu/embed.json?hide_title=true&new_viewer=false'
-      expect(embed.attr('href').to_s).to eq('https://purl.stanford.edu/bf973rp9392')
+      expect(rendered).to have_css '[data-controller="oembed"]'
     end
 
     it 'displays a non-javascript fallback' do


### PR DESCRIPTION
This hasn't been used since we switched to stimulus and it is just a link to the current page that we are on.