### PR TITLE
Extract ItemType class from PurlVersion

### DIFF
--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -4,7 +4,8 @@ require 'iiif/presentation'
 require 'iiif/v3/presentation'
 
 class Iiif3PresentationManifest < IiifPresentationManifest
-  delegate :object?, :geo?, :image?, :map?, :three_d?, to: :purl_version
+  delegate :object?, :geo?, :image?, :map?, :three_d?, to: :item_type
+
   delegate :file_sets, to: :structural_metadata
   attr_reader :purl_base_uri
 

--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -5,8 +5,9 @@ require 'iiif/presentation'
 class IiifPresentationManifest
   include ActiveModel::Model
 
-  delegate :druid, :display_title, :book?, :structural_metadata, :public_xml_document, :cocina, :updated_at, :containing_purl_collections,
-           :collection?, :cocina_display, to: :purl_version
+  delegate :druid, :display_title, :structural_metadata, :public_xml_document, :cocina, :updated_at, :containing_purl_collections,
+           :cocina_display, :item_type, to: :purl_version
+  delegate :collection?, :book?, to: :item_type
   delegate :copyright, to: :cocina_display
 
   delegate :url_for, to: :controller

--- a/app/models/item_type.rb
+++ b/app/models/item_type.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class ItemType
+  def initialize(type)
+    @type = type
+  end
+
+  attr_reader :type
+
+  def collection?
+    type == 'https://cocina.sul.stanford.edu/models/collection'
+  end
+
+  def book?
+    type == 'https://cocina.sul.stanford.edu/models/book'
+  end
+
+  def image?
+    type == 'https://cocina.sul.stanford.edu/models/image'
+  end
+
+  def map?
+    type == 'https://cocina.sul.stanford.edu/models/map'
+  end
+
+  def geo?
+    type == 'https://cocina.sul.stanford.edu/models/geo'
+  end
+
+  def three_d?
+    type == 'https://cocina.sul.stanford.edu/models/3d'
+  end
+
+  def webarchive_seed?
+    type == 'https://cocina.sul.stanford.edu/models/webarchive-seed'
+  end
+
+  def webarchive_binary?
+    type == 'https://cocina.sul.stanford.edu/models/webarchive-binary'
+  end
+
+  def object?
+    type == 'https://cocina.sul.stanford.edu/models/object'
+  end
+end

--- a/app/models/purl_version.rb
+++ b/app/models/purl_version.rb
@@ -68,6 +68,7 @@ class PurlVersion # rubocop:disable Metrics/ClassLength
   end
 
   delegate :containing_collections, to: :structural_metadata
+  delegate :collection?, :webarchive_seed?, :webarchive_binary?, to: :item_type
 
   # @returns [Bool] are there resources that can be shown?
   # This prevents adding links to the embed service, when that service can't generate a valid response.
@@ -103,20 +104,16 @@ class PurlVersion # rubocop:disable Metrics/ClassLength
     return false if collection?
 
     resource_types = structural_metadata.file_sets.map(&:type)
-    if (image? || book? || map?) &&
+    if (item_type.image? || item_type.book? || item_type.map?) &&
        (structural_metadata.virtual_object? || resource_types.include?('https://cocina.sul.stanford.edu/models/resources/image'))
       true
     else
-      book? && resource_types.include?('https://cocina.sul.stanford.edu/models/resources/page')
+      item_type.book? && resource_types.include?('https://cocina.sul.stanford.edu/models/resources/page')
     end
   end
 
   def iiif3_manifest(**)
     @iiif3_manifest ||= Iiif3PresentationManifest.new(self, **)
-  end
-
-  def collection?
-    cocina['type'] == 'https://cocina.sul.stanford.edu/models/collection'
   end
 
   def collection_items_link
@@ -145,36 +142,8 @@ class PurlVersion # rubocop:disable Metrics/ClassLength
       @type ||= cocina['type']
     end
 
-    def book?
-      type == 'https://cocina.sul.stanford.edu/models/book'
-    end
-
-    def image?
-      type == 'https://cocina.sul.stanford.edu/models/image'
-    end
-
-    def map?
-      type == 'https://cocina.sul.stanford.edu/models/map'
-    end
-
-    def geo?
-      type == 'https://cocina.sul.stanford.edu/models/geo'
-    end
-
-    def three_d?
-      type == 'https://cocina.sul.stanford.edu/models/3d'
-    end
-
-    def webarchive_seed?
-      type == 'https://cocina.sul.stanford.edu/models/webarchive-seed'
-    end
-
-    def webarchive_binary?
-      type == 'https://cocina.sul.stanford.edu/models/webarchive-binary'
-    end
-
-    def object?
-      type == 'https://cocina.sul.stanford.edu/models/object'
+    def item_type
+      @item_type ||= ItemType.new(cocina['type'])
     end
 
     def folio_instance_hrid


### PR DESCRIPTION
This groups all the methods about the item's type into a single class that has no other responsibilities.