### PR TITLE
Drop the optional okcomputer checks

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -14,29 +14,6 @@ OkComputer::Registry.register 'ruby_version', OkComputer::RubyVersionCheck.new
 
 OkComputer::Registry.register 'stacks_fs', OkComputer::DirectoryCheck.new('/stacks')
 
-# NOTE:
-# Settings.purl_resource.public_xml, Settings.purl_resource.mods, and Settings.purl_resource.iiif_manifest
-#   exist in the document cache root on deployed environments.
-# The document cache root check should be sufficient for these.
-
-# NOTE: Settings.stacks.iiif_profile is a static service to tell services what renderer to use for IIIF
-#  and therefore doesn't need to be considered a dependency here
-
-# ------------------------------------------------------------------------------
-
-# NON-CRUCIAL (Optional) checks, avail at /status/<name-of-check>
-#   - at individual endpoint, HTTP response code reflects the actual result
-#   - in /status/all, these checks will display their result text, but will not affect HTTP response code
-OkComputer::Registry.register 'stacks_service', OkComputer::HttpCheck.new(Settings.stacks.url)
-
-# OEmbed service
-TEST_DRUID = 'pv954fv1448' # in both purl/stacks prod and purl/stacks test
-resource_url = Settings.embed.url.sub('%{druid}', TEST_DRUID)
-OkComputer::Registry.register 'embed_service',
-  OkComputer::HttpCheck.new(Settings.embed.iframe.url_template.sub('{?url*}', "?url=#{resource_url}"))
-
-OkComputer.make_optional %w(stacks_service embed_service)
-
 ActiveSupport.on_load(:action_controller) do
   OkComputer::Registry.register 'feedback_mailer', OkComputer::ActionMailerCheck.new(FeedbackMailer)
 


### PR DESCRIPTION
These are never run, so they are not useful.

The dependency here was backward. Stacks and sul-embed depend on Purl, not the otherway around