### PR TITLE
Rename PurlResource to Purl

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception, except: [:options]
 
-  rescue_from PurlResource::DruidNotValid, with: :invalid_druid
+  rescue_from Purl::DruidNotValid, with: :invalid_druid
   rescue_from PurlVersion::ObjectNotReady, with: :object_not_ready
 
   def options

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -81,7 +81,7 @@ class IiifController < ApplicationController
 
   # validate that the id is of the proper format
   def load_purl
-    @purl = PurlResource.find(params[:purl_id] || params[:id])
+    @purl = Purl.find(params[:purl_id] || params[:id])
   end
 
   def load_version

--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -72,7 +72,7 @@ class PurlController < ApplicationController
 
   # validate that the id is of the proper format
   def load_purl
-    @purl = PurlResource.find(params[:id])
+    @purl = Purl.find(params[:id])
   end
 
   def load_version

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   end
 
   def link_to_purl(druid)
-    link_to PurlResource.find(druid).version(:head).display_title, purl_url(druid), class: 'su-underline'
+    link_to Purl.find(druid).version(:head).display_title, purl_url(druid), class: 'su-underline'
   rescue StandardError
     link_to druid, purl_url(druid), class: 'su-underline'
   end

--- a/app/models/iiif3_presentation_manifest.rb
+++ b/app/models/iiif3_presentation_manifest.rb
@@ -111,12 +111,12 @@ class Iiif3PresentationManifest < IiifPresentationManifest
   end
 
   # Cocina only lists druids for collection objects, not filesets
-  # We need to go grab the PurlResource for the druid
+  # We need to go grab the Purl for the druid
   # It seems like we are only doing this for type images. I am not sure why
   def add_virtual_object_canvases(manifest)
     # For each valid virtual object image, create a canvas for its thumbnail
     structural_metadata.members&.each do |member_druid|
-      purl_version = PurlResource.find(member_druid.delete_prefix('druid:')).version(:head)
+      purl_version = Purl.find(member_druid.delete_prefix('druid:')).version(:head)
       # We are using .thumbail here to get the first image in the object
       thumbnail_fs = purl_version.thumbnail_service.thumb_fs
       # Overwrite default label for virtual objects

--- a/app/models/iiif_presentation_manifest.rb
+++ b/app/models/iiif_presentation_manifest.rb
@@ -114,7 +114,7 @@ class IiifPresentationManifest
 
     # For each valid virtual object image, create a canvas for its thumbnail
     structural_metadata.members&.each do |member_druid|
-      purl_version = PurlResource.find(member_druid.delete_prefix('druid:')).version(:head)
+      purl_version = Purl.find(member_druid.delete_prefix('druid:')).version(:head)
       # We are using thumbnail here to get the first image in the object
       thumbnail_file = purl_version.thumbnail
       # Overwrite default label for virtual objects

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PurlResource
+class Purl
   include ActiveModel::Model
 
   attr_accessor :id
@@ -11,7 +11,7 @@ class PurlResource
   def self.find(id)
     raise DruidNotValid, id unless Dor::Util.validate_druid(id)
 
-    PurlResource.new(id:)
+    Purl.new(id:)
   end
 
   def persisted?

--- a/app/models/purl_version.rb
+++ b/app/models/purl_version.rb
@@ -51,7 +51,7 @@ class PurlVersion # rubocop:disable Metrics/ClassLength
   # @return [Array<Array>] a list of PURL resources, PurlVersion tuples of the collections this item is a member of
   def containing_purl_collections
     @containing_purl_collections ||= containing_collections.filter_map do |id|
-      resource = PurlResource.find(id)
+      resource = Purl.find(id)
       return nil unless resource.version(:head).ready?
 
       [resource, resource.version(:head)]

--- a/app/services/thumbnail_service.rb
+++ b/app/services/thumbnail_service.rb
@@ -15,8 +15,8 @@ class ThumbnailService
     return if structural.members.empty?
 
     begin
-      self.class.new(PurlResource.find(structural.members.first.delete_prefix('druid:')).version(:head).structural_metadata).thumb
-    rescue PurlResource::DruidNotValid
+      self.class.new(Purl.find(structural.members.first.delete_prefix('druid:')).version(:head).structural_metadata).thumb
+    rescue Purl::DruidNotValid
       Honeybadger.notify("Unable to find thumbnail for #{id}. Tried #{structural.members.first}")
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Purl
+module PurlApplication
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0

--- a/spec/components/access_component_spec.rb
+++ b/spec/components/access_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AccessComponent, type: :component do
   subject(:component) { described_class.new(version:) }
 
-  let(:purl) { PurlResource.new(id: druid) }
+  let(:purl) { Purl.new(id: druid) }
   let(:druid) { 'bb737zp0787' }
   let(:version) { purl.version(:head) }
 

--- a/spec/components/bibliographic_component_spec.rb
+++ b/spec/components/bibliographic_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe BibliographicComponent, type: :component do
   subject(:component) { described_class.new(version:) }
 
-  let(:purl) { PurlResource.new(id: druid) }
+  let(:purl) { Purl.new(id: druid) }
   let(:druid) { 'bb000qr5025' }
   let(:version) { purl.version(:head) }
 

--- a/spec/components/contributors_component_spec.rb
+++ b/spec/components/contributors_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ContributorsComponent, type: :component do
   subject(:component) { described_class.new(version: version) }
 
-  let(:purl) { PurlResource.new(id: druid) }
+  let(:purl) { Purl.new(id: druid) }
   let(:version) { purl.version(:head) }
 
   before do

--- a/spec/components/description_component_spec.rb
+++ b/spec/components/description_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe DescriptionComponent, type: :component do
   subject(:component) { described_class.new(version:) }
 
-  let(:version) { PurlResource.new(id: druid).version(:head) }
+  let(:version) { Purl.new(id: druid).version(:head) }
 
   before do
     render_inline(component)

--- a/spec/components/show/body_component_spec.rb
+++ b/spec/components/show/body_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Show::BodyComponent, type: :component do
   subject(:component) { described_class.new(version:) }
 
-  let(:version) { PurlResource.new(id: druid).version(:head) }
+  let(:version) { Purl.new(id: druid).version(:head) }
 
   before do
     render_inline(component)

--- a/spec/components/show/description/related_resources_field_component_spec.rb
+++ b/spec/components/show/description/related_resources_field_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Show::Description::RelatedResourcesFieldComponent, type: :compone
   subject(:component) { described_class.new(related_resources_field:) }
 
   let(:values) do
-    PurlResource.new(id: druid).version(:head).cocina_display.related_resource_display_data
+    Purl.new(id: druid).version(:head).cocina_display.related_resource_display_data
   end
 
   let(:related_resources_field) { values.first }

--- a/spec/components/show/head_metadata_component_spec.rb
+++ b/spec/components/show/head_metadata_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Show::HeadMetadataComponent, type: :component do
   subject(:component) { described_class.new(purl:, version:) }
 
-  let(:purl) { PurlResource.new(id: druid) }
+  let(:purl) { Purl.new(id: druid) }
   let(:version) { purl.version(:head) }
 
   context 'with a version that is not the head' do

--- a/spec/components/show/sidebar_component_spec.rb
+++ b/spec/components/show/sidebar_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Show::SidebarComponent, type: :component do
   subject(:component) { described_class.new(purl:, version:) }
 
-  let(:purl) { PurlResource.new(id: druid) }
+  let(:purl) { Purl.new(id: druid) }
   let(:version) { purl.version(:head) }
 
   before do

--- a/spec/components/subject_component_spec.rb
+++ b/spec/components/subject_component_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SubjectComponent, type: :component do
   subject(:component) { described_class.new(version:) }
 
-  let(:version) { PurlResource.new(id: druid).version(:head) }
+  let(:version) { Purl.new(id: druid).version(:head) }
 
   before do
     render_inline(component)

--- a/spec/components/versions_component_spec.rb
+++ b/spec/components/versions_component_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe VersionsComponent, type: :component do
   let(:instance) { described_class.new(purl:, version: purl.version(:head)) }
-  let(:purl) { PurlResource.new(id: 'zb733jx3137') }
+  let(:purl) { Purl.new(id: 'zb733jx3137') }
 
   before do
     vc_test_controller.request.env['HTTPS'] = 'on'

--- a/spec/model/iiif3_metadata_writer_spec.rb
+++ b/spec/model/iiif3_metadata_writer_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe Iiif3MetadataWriter do
 
     context 'with digital collections style data' do
       let(:cocina_descriptive) do
-        PurlResource.find('bb157hs6068').version(:head).cocina['description']
+        Purl.find('bb157hs6068').version(:head).cocina['description']
       end
 
       it 'extracts the metadata' do
@@ -394,7 +394,7 @@ RSpec.describe Iiif3MetadataWriter do
 
     context 'with extent and map coordinates' do
       let(:cocina_descriptive) do
-        PurlResource.find('bb157hs6068').version(:head).cocina['description']
+        Purl.find('bb157hs6068').version(:head).cocina['description']
       end
 
       it 'extracts the metadata' do
@@ -515,7 +515,7 @@ RSpec.describe Iiif3MetadataWriter do
 
     context 'with table of contents in notes' do
       let(:cocina_descriptive) do
-        PurlResource.find('bc854fy5899').version(:head).cocina['description']
+        Purl.find('bc854fy5899').version(:head).cocina['description']
       end
 
       it 'extracts the metadata' do
@@ -525,7 +525,7 @@ RSpec.describe Iiif3MetadataWriter do
 
     context 'with publisher' do
       let(:cocina_descriptive) do
-        PurlResource.find('zf119tw4418').version(:head).cocina['description']
+        Purl.find('zf119tw4418').version(:head).cocina['description']
       end
 
       it 'extracts the metadata' do
@@ -554,7 +554,7 @@ RSpec.describe Iiif3MetadataWriter do
 
     context 'when the title has parallelValues' do
       let(:cocina_descriptive) do
-        PurlResource.find('bb070yy8209').version(:head).cocina['description']
+        Purl.find('bb070yy8209').version(:head).cocina['description']
       end
 
       it 'extracts all the titles and contributors correctly' do

--- a/spec/model/iiif3_presentation_manifest_spec.rb
+++ b/spec/model/iiif3_presentation_manifest_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Iiif3PresentationManifest do
   describe '#body' do
     subject(:json) { manifest.body.to_ordered_hash }
 
-    let(:resource) { PurlResource.find(druid).version(:head) }
+    let(:resource) { Purl.find(druid).version(:head) }
     let(:request) { ActionDispatch::TestRequest.create }
 
     before do

--- a/spec/model/iiif_presentation_manifest_spec.rb
+++ b/spec/model/iiif_presentation_manifest_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe IiifPresentationManifest do
 
     let(:controller) { PurlController.new }
 
-    let(:resource) { PurlResource.find(druid).version(:head) }
+    let(:resource) { Purl.find(druid).version(:head) }
     let(:request) { ActionDispatch::TestRequest.create }
 
     before do

--- a/spec/model/purl_resource_spec.rb
+++ b/spec/model/purl_resource_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe PurlResource do
+RSpec.describe Purl do
   let(:instance) { described_class.new(id: druid) }
   let(:druid) { nil }
 
   describe '.find' do
     it 'validates the druid' do
-      expect { described_class.find('xyz') }.to raise_error PurlResource::DruidNotValid
+      expect { described_class.find('xyz') }.to raise_error Purl::DruidNotValid
     end
   end
 

--- a/spec/requests/iiif3_manifest_spec.rb
+++ b/spec/requests/iiif3_manifest_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe 'IIIF v3 manifests' do
 
   context 'when the object has no published files' do
     let(:druid) { 'bg387kw8222' }
-    let(:resource) { instance_double(PurlResource, version:) }
+    let(:resource) { instance_double(Purl, version:) }
     let(:version) { instance_double(PurlVersion, updated_at: 2.days.ago, cache_key: 'resource/xxx', ready?: true) }
 
     before do
-      allow(PurlResource).to receive(:find).and_return(resource)
+      allow(Purl).to receive(:find).and_return(resource)
       allow(version).to receive(:iiif3_manifest).and_raise(IIIF::V3::Presentation::MissingRequiredKeyError)
       allow(version).to receive(:embeddable?)
       allow(version).to receive(:collection?)

--- a/spec/requests/purl_spec.rb
+++ b/spec/requests/purl_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'PURL API' do
         end
 
         before do
-          allow(PurlResource).to receive(:find).and_return(instance_double(PurlResource, version:))
+          allow(Purl).to receive(:find).and_return(instance_double(Purl, version:))
         end
 
         it 'returns the Cocina json for the requested version' do
@@ -153,7 +153,7 @@ RSpec.describe 'PURL API' do
         end
 
         before do
-          allow(PurlResource).to receive(:find).and_return(instance_double(PurlResource, version:))
+          allow(Purl).to receive(:find).and_return(instance_double(Purl, version:))
         end
 
         it 'returns the public XML for the requested version' do
@@ -225,11 +225,11 @@ RSpec.describe 'PURL API' do
             }
           COCINA
         end
-        let(:purl_resource) { PurlResource.new(id: 'bw368gx2874') }
+        let(:purl_resource) { Purl.new(id: 'bw368gx2874') }
         let(:releases) { instance_double(Releases, crawlable?: false) }
 
         before do
-          allow(PurlResource).to receive(:find).and_return(purl_resource)
+          allow(Purl).to receive(:find).and_return(purl_resource)
           allow(purl_resource).to receive_messages(version:, releases:)
         end
 

--- a/spec/views/purl/_embed.html.erb_spec.rb
+++ b/spec/views/purl/_embed.html.erb_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'purl/_embed' do
   before { assign(:purl, purl) }
 
-  let(:purl) { PurlResource.new(id: 'bf973rp9392') }
+  let(:purl) { Purl.new(id: 'bf973rp9392') }
 
   it 'displays a purl embed viewer' do
     render


### PR DESCRIPTION
We no longer have a resource representing the abstract concept of the purl that we used to have, we only have versions.  This also helps align Rails expectation that the route name (`resources :purls')  match the model name (now `Purl`).