### PR TITLE
stop trying to delete files that do not exist

### DIFF
--- a/app/services/fixture_loader.rb
+++ b/app/services/fixture_loader.rb
@@ -10,7 +10,5 @@ class FixtureLoader
 
     FileUtils.mkdir_p(dest)
     `scp -r lyberadmin@#{machine}:#{src} #{dest}`
-    FileUtils.rm "#{dest}/versions/cocina.json"
-    FileUtils.rm "#{dest}/versions/public.xml"
   end
 end


### PR DESCRIPTION
Since we aren't writing this file anymore fixture loader errors out because these files don't exist