### PR TITLE
fix table overflow

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -41,7 +41,7 @@
 
     .section-body {
       /* prevent URLs from overflowing the "Abstract" area */
-      overflow-wrap: break-word;
+      word-break: break-word;
 
       th {
         padding-left: 0px;


### PR DESCRIPTION
closes #1658.

This was happening because the table was overflowing outside the section div. This fixes it. table-layout:fixed; on the table element would also fix this.