### PR TITLE
auto_link abstract text

### DIFF
--- a/app/components/abstract_contents_component.html.erb
+++ b/app/components/abstract_contents_component.html.erb
@@ -3,7 +3,7 @@
   <% items.each do |item| %>
     <dt><%= item.label %></dt>
     <% item.values.each do |value| %>
-      <dd><%= value %></dd>
+      <dd><%= auto_link(value, html: { class: 'su-underline' }) %></dd>
     <% end %>
   <% end %>
   </dl>


### PR DESCRIPTION
The screenshot in https://github.com/sul-dlss/purl/issues/1047 shows that the links in abstract were hyperlinks. We aren't currently doing this.


Before:
<img width="667" height="497" alt="Screenshot 2025-10-01 at 5 56 14 PM" src="https://github.com/user-attachments/assets/9deef9f5-aeb9-440d-88c4-248f4fab04e1" />

After:

<img width="643" height="476" alt="Screenshot 2025-10-02 at 10 47 39 AM" src="https://github.com/user-attachments/assets/8ab1707b-25c4-4c6f-970c-46a2c7bec233" />
