### PR TITLE
Display related link as a block element

### DIFF
--- a/app/components/show/description/labelled_link_component.html.erb
+++ b/app/components/show/description/labelled_link_component.html.erb
@@ -1,1 +1,1 @@
-<a href="<%= url %>"><%= link_text %></a>
+<p><a href="<%= url %>"><%= link_text %></a></p>


### PR DESCRIPTION
So they don't all run together.

Fixes #1666
Before
<img width="768" height="186" alt="Screenshot 2025-10-03 at 12 47 38 PM" src="https://github.com/user-attachments/assets/f1d99f99-588c-4f8c-9acb-38d54d1911bf" />


After
<img width="769" height="244" alt="Screenshot 2025-10-03 at 12 47 12 PM" src="https://github.com/user-attachments/assets/617d3fc7-0293-4e83-9f34-36247a562f24" />
