### PR TITLE
Default to using the local MinIO bucket in development

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,13 @@
 stacks:
   root: <%= File.join(Rails.root, "spec", "fixtures", "stacks") %>
 
+# Default to using the local MinIO bucket
+s3:
+  access_key_id: minio-user
+  secret_access_key: minio-password
+  bucket: stacks-test
+  endpoint: http://localhost:9000
+
 # These are both the test fixtures and the links from the index page.
 landing_page_druids:
   - bb000qr5025 # image where jp2 is not downloadable


### PR DESCRIPTION
This way the local dev server works out of the box, instead of
throwing errors about missing credentials for production.
