### PR TITLE
A missing meta.json shouldn't prevent purl page from drawing

### DIFF
--- a/app/models/null_releases.rb
+++ b/app/models/null_releases.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Represents a Purl with no releases (meta.json not found)
+# See Releases for more details
+class NullReleases
+  def crawlable?
+    false
+  end
+
+  def released_to_searchworks?
+    false
+  end
+
+  def released_to_earthworks?
+    false
+  end
+end

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -37,7 +37,12 @@ class Purl
   end
 
   def releases
-    @releases ||= Releases.new(meta_json)
+    @releases ||= begin
+      Releases.new(meta_json)
+    rescue ResourceRetriever::ResourceNotFound
+      # meta.json not found, so no releases. This may happen if the releaseWF has not yet completed.
+      NullReleases.new
+    end
   end
 
   # The meta.json contains the properties this purl is released to.

--- a/spec/model/null_releases_spec.rb
+++ b/spec/model/null_releases_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NullReleases do
+  subject(:instance) { described_class.new }
+
+  describe '#crawlable?' do
+    subject { instance.crawlable? }
+
+    it { is_expected.to be false }
+  end
+
+  describe '#released_to_searchworks?' do
+    subject { instance.released_to_searchworks? }
+
+    it { is_expected.to be false }
+  end
+
+  describe '#released_to_earthworks?' do
+    subject { instance.released_to_earthworks? }
+
+    it { is_expected.to be false }
+  end
+end

--- a/spec/model/purl_spec.rb
+++ b/spec/model/purl_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Purl do
+  subject(:instance) { described_class.new(id: druid) }
+
+  describe '#releases' do
+    subject { instance.releases }
+
+    context 'with releases' do
+      let(:druid) { 'bb000qr5025' }
+
+      it { is_expected.to be_instance_of(Releases) }
+    end
+
+    context 'without releases' do
+      let(:druid) { 'bw368gx2874' }
+
+      it { is_expected.to be_instance_of(NullReleases) }
+    end
+  end
+end


### PR DESCRIPTION
The meta.json can be missing if the releaseWF hasn't run yet