### PR TITLE
Use lists to render tables of contents

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -106,3 +106,9 @@
 .grecaptcha-badge {
   visibility: hidden;
 }
+
+/* Don't number table of contents lists, even though they are ordered */
+ol.table-of-contents {
+  list-style-type: none;
+  padding-left: 0;
+}

--- a/app/components/abstract_contents_component.html.erb
+++ b/app/components/abstract_contents_component.html.erb
@@ -1,9 +1,21 @@
 <%= render SectionComponent.new(label: 'Abstract/Contents') do %>
   <dl>
-  <% items.each do |item| %>
+  <% cocina_display.abstract_display_data.each do |item| %>
     <dt><%= item.label %></dt>
     <% item.values.each do |value| %>
       <dd><%= auto_link(value, html: { class: 'su-underline' }) %></dd>
+    <% end %>
+  <% end %>
+  <% cocina_display.table_of_contents_display_data.each do |item| %>
+    <dt><%= item.label %></dt>
+    <% item.objects.each do |toc| %>
+      <dd>
+        <ol class="table-of-contents">
+          <% toc.values.each do |value| %>
+            <li><%= auto_link(value, html: { class: 'su-underline' }) %></li>
+          <% end %>
+        </ol>
+      </dd>
     <% end %>
   <% end %>
   </dl>

--- a/app/components/abstract_contents_component.rb
+++ b/app/components/abstract_contents_component.rb
@@ -10,11 +10,7 @@ class AbstractContentsComponent < ViewComponent::Base
 
   delegate :cocina_display, to: :version
 
-  def items
-    @items ||= cocina_display.abstract_display_data + cocina_display.table_of_contents_display_data
-  end
-
   def render?
-    items.present?
+    (cocina_display.abstract_display_data + cocina_display.table_of_contents_display_data).present?
   end
 end


### PR DESCRIPTION
This improves the visual presentation for items with tables of
contents, since we can often split them up based on delimiters.
