### PR TITLE
Correctly render multiple contact emails

### DIFF
--- a/app/components/contact_component.html.erb
+++ b/app/components/contact_component.html.erb
@@ -1,8 +1,10 @@
 <%= render SectionComponent.new(label: 'Contact information') do %>
   <dl>
-    <% contact_email_display_data.each do |contact| %>
-      <dt class="visually-hidden"><%= contact.label %></dt>
-      <dd><%= auto_link contact.values.first, html: { class: 'su-underline' } %></dd>
+    <% cocina_display.contact_email_display_data.each do |field| %>
+      <%= tag.dt field.label, class: 'visually-hidden' %>
+      <% field.values.each do |value| %>
+        <%= tag.dd auto_link(value, html: { class: 'su-underline' }) %>
+      <% end %>
     <% end %>
   </dl>
 <% end %>

--- a/app/components/contact_component.rb
+++ b/app/components/contact_component.rb
@@ -9,9 +9,8 @@ class ContactComponent < ViewComponent::Base
   attr_reader :version
 
   delegate :cocina_display, to: :version
-  delegate :contact_email_display_data, to: :cocina_display
 
   def render?
-    contact_email_display_data.present?
+    cocina_display&.contact_email_display_data.present?
   end
 end


### PR DESCRIPTION
This ports the same logic/template used in Searchworks, which
is correct. Tested on yr306cd5969.
